### PR TITLE
Fix to CRUD '/form' replace - PHP8.0+

### DIFF
--- a/Tina4/Routing/Router.php
+++ b/Tina4/Routing/Router.php
@@ -372,9 +372,16 @@ class Router extends Data
                         $result = $this->getRouteResult($route["class"], $route["function"], $params);
                     } else {
                         //Fail over to formToken, but payload must match the route
-                        //CRUD fix for built in values of form & {id}
+                        //CRUD fix for built-in values of form & {id}
+
+                        //Ensure the replaced '/form' is at the end of the route path when removing
+                        if(str_ends_with($route["routePath"], '/form')) {
+                            $route["routePath"] = substr_replace($route["routePath"], '', strrpos($route["routePath"], '/form'), 5);
+                        }
+
                         $route["routePath"] = str_replace("/form", "", $route["routePath"]);
                         $route["routePath"] = str_replace("/{id}", "", $route["routePath"]);
+
                         if (isset($_REQUEST["formToken"]) && $route["method"] === TINA4_GET && $this->config->getAuthentication()->validToken($_REQUEST["formToken"])
                             && $this->config->getAuthentication()->getPayLoad($_REQUEST["formToken"])["payload"] === $route["routePath"])
                         {

--- a/Tina4/Routing/Router.php
+++ b/Tina4/Routing/Router.php
@@ -379,7 +379,6 @@ class Router extends Data
                             $route["routePath"] = substr_replace($route["routePath"], '', strrpos($route["routePath"], '/form'), 5);
                         }
 
-                        $route["routePath"] = str_replace("/form", "", $route["routePath"]);
                         $route["routePath"] = str_replace("/{id}", "", $route["routePath"]);
 
                         if (isset($_REQUEST["formToken"]) && $route["method"] === TINA4_GET && $this->config->getAuthentication()->validToken($_REQUEST["formToken"])


### PR DESCRIPTION
Note: str_ends_with() is only available from PHP 8.0 onwards
- Ensure '/form' is only removed when at the end of route string (not all iterations)