### PR TITLE
bug: ERROR:str_replace() Passing null to parameter #2

### DIFF
--- a/Tina4/Routing/ParseTemplate.php
+++ b/Tina4/Routing/ParseTemplate.php
@@ -320,7 +320,7 @@ class ParseTemplate
         if (isset($_SESSION)) {
             foreach ($_SESSION as $varName => $value) {
                 if (!is_array($value) && !is_object($value)) {
-                    $content = str_replace('{{' . $varName . '}}', $value, $content);
+                    $content = str_replace('{{' . $varName . '}}', $value ?? '', $content);
                 }
             }
         }


### PR DESCRIPTION
ERROR:str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated

         \public_html\vendor\tina4stack\tina4php\Tina4\Routing\ParseTemplate.php:323]

Preventing me from accessing my images.

Fixed the error and it works for me