### PR TITLE
Backwards compatability for PR65

### DIFF
--- a/Tina4/Routing/Router.php
+++ b/Tina4/Routing/Router.php
@@ -375,7 +375,7 @@ class Router extends Data
                         //CRUD fix for built-in values of form & {id}
 
                         //Ensure the replaced '/form' is at the end of the route path when removing
-                        if(str_ends_with($route["routePath"], '/form')) {
+                        if(substr($route["routePath"], -5,5) == '/form') {
                             $route["routePath"] = substr_replace($route["routePath"], '', strrpos($route["routePath"], '/form'), 5);
                         }
 


### PR DESCRIPTION
replaces the php 8 only code with something handled by php 7.
related to Pull Request #65 