### PR TITLE
Bugfix/images called as methods

### DIFF
--- a/Tina4/Routing/ParseTemplate.php
+++ b/Tina4/Routing/ParseTemplate.php
@@ -157,9 +157,11 @@ class ParseTemplate
                     $this->fileName = $realFileName;
                     if (!is_dir($realFileName)) {
                         $content = file_get_contents($realFileName);
-                        $content = $this->parseSnippets($content);
-                        $content = $this->parseCalls($content);
-                        $content = $this->parseVariables($content);
+                        if(!$this->isImage($mimeType)){
+                            $content = $this->parseSnippets($content);
+                            $content = $this->parseCalls($content);
+                            $content = $this->parseVariables($content);
+                        }
                     } else {
                         Debug::message("$this->GUID Returning File not found {$fileName}", TINA4_LOG_DEBUG);
                         $this->headers[] = "Tina4-Debug: ".$this->GUID;
@@ -181,6 +183,21 @@ class ParseTemplate
             }
         }
         return $content;
+    }
+
+    /**
+     * Determines if mimeType starts with image
+     * @param $mimeType
+     * @return bool
+     */
+    public function isImage($mimeType)
+    {
+        $isImage = false;
+        if(strpos($mimeType, "image") === 0){
+            $isImage = true;
+        }
+
+        return $isImage;
     }
 
     /**

--- a/src/templates/documentation/advanced/threads.twig
+++ b/src/templates/documentation/advanced/threads.twig
@@ -1,0 +1,38 @@
+{% set title = 'Threads' %}
+
+{% set introduction %}
+    If services do not meet the required use case, perhaps one wants a more immediate action, or the server environment
+    does not allow command line interaction, threads could be an option.
+{% endset %}
+
+{% set requirements = ['Threads', 'Routing'] %}
+
+{% set content %}
+    <h5>Registering a thread</h5>
+    <p>Adding a trigger to start a thread, can be done anywhere in the code. Just remember that it has to have run before
+    actually calling the trigger. If the use case is just to start a thread, then the trigger registration and trigger call
+    can happen in the same place. If the trigger needs to be used in multiple places, probably best to place it somewhere
+    that the composer autoload will find it. Suggestion is to create a triggers.php file in the "src/app"
+        <pre><code>{{ include_code("examples/advanced-threads-register.twig"| raw) }}</code></pre>
+    </p>
+
+    <h5>Firing off a thread</h5>
+    <p>A simple line of code fires off the thread. It uses the trigger name, and an array of parameters. The order of the
+    parameters, matches the order of arguments in the trigger function.
+    <pre><code>{{ include_code("examples/advanced-threads-fire.twig"| raw) }}</code></pre>
+    </p>
+
+    <h5>Debugging threads</h5>
+    <p>The getEvents() method in the Thread class can be used to see what handlers (registered Threads) and events
+        (Thread calls) exists upto the point of calling the method.
+    <pre><code>{{ include_code("examples/advanced-threads-get.twig"| raw) }}</code></pre>
+    </p>
+{% endset %}
+
+{% set tips = [
+    'The thread code is not allowed to have comments and can only have simple variables',
+    'To register a thread you can use onTrigger or addTrigger'
+]
+%}
+
+{% include "documentation/components/help-segment.twig" %}

--- a/src/templates/documentation/examples/advanced-threads-fire.twig
+++ b/src/templates/documentation/examples/advanced-threads-fire.twig
@@ -1,0 +1,6 @@
+\Tina4\Get::add("/test-trigger", function (\Tina4\Response $response) {
+
+    \Tina4\Thread::trigger("register-me", ["Tina", "Good morning"]);
+
+    return $response("This will add to the file: 'Good morning, Tina'");
+});

--- a/src/templates/documentation/examples/advanced-threads-get.twig
+++ b/src/templates/documentation/examples/advanced-threads-get.twig
@@ -1,0 +1,1 @@
+$debugThreads = \Tina4\Thread::getEvents()

--- a/src/templates/documentation/examples/advanced-threads-register.twig
+++ b/src/templates/documentation/examples/advanced-threads-register.twig
@@ -1,0 +1,7 @@
+<?php
+
+\Tina4\Thread::onTrigger("register-me", static function ($name, $greeting) {
+
+    file_put_contents("trigger.txt", "{$greeting}, {$name}", FILE_APPEND);
+
+});

--- a/src/templates/documentation/index.twig
+++ b/src/templates/documentation/index.twig
@@ -136,6 +136,7 @@
                         <div class="accordion-body">
                             <p><a href="#advanced-modules">Modules</a></p>
                             <p><a href="#advanced-services">Services</a></p>
+                            <p><a href="#advanced-threads">Threads</a></p>
                         </div>
                     </div>
                 </div>
@@ -264,6 +265,7 @@
             <h2>Advanced</h2>
             {% include "documentation/advanced/modules.twig" with { anchor: 'advanced-modules' } %}
             {% include "documentation/advanced/services.twig" with { anchor: 'advanced-services' } %}
+            {% include "documentation/advanced/threads.twig" with { anchor: 'advanced-threads' } %}
             <h2>Contributing</h2>
             <a href="https://loom.com/invite/6a3f0227ce5e4123909a853d07d35612">Making videos on Loom</a>
             <h2>Setup Environment</h2>


### PR DESCRIPTION
Some images are triggering the parseCalls method to try execute a method, resulting in a php error. 
The fix bypasses all those calls based on mimeType.
Attached file used for testing and is one of the offending files.
![sensei](https://github.com/tina4stack/tina4-php/assets/62340127/36c0214d-52a4-4efb-9ffa-3abb68235dc7)
