### PR TITLE
Update GitDeploy.php to fix gitBinary missing issue

### DIFF
--- a/Tina4/Deploy/GitDeploy.php
+++ b/Tina4/Deploy/GitDeploy.php
@@ -98,7 +98,6 @@ class GitDeploy
             $this->cleanPath($stagingPath, true);
 
             $gitBinary = $this->getBinPath("git");
-            $gitBinary = "";
 
             if (empty($gitBinary)) {
                 $this->log("Deployment failed! Git binary not found, trying to do wget", TINA4_LOG_ERROR);


### PR DESCRIPTION
Removed the $gitBinary = "" as this is causing the deploy to fail even if the git binary is installed on the system