### PR TITLE
Email Fail message

### DIFF
--- a/Tina4/Messaging/Messenger.php
+++ b/Tina4/Messaging/Messenger.php
@@ -179,6 +179,7 @@ class Messenger
                     Debug::message("Message results" . $messageLog, TINA4_LOG_DEBUG);
                 } catch (\Exception $e) {
                     $mailSent = false;
+                    $this->lastMessageLog = $e->getMessage();
                     Debug::message("Messenger Error:" . $e->getMessage());
                 }
             }


### PR DESCRIPTION
Added lastMessageLog into catch for when phpMailer throws an exception.