### PR TITLE
fix(cli): tina4php migrate exits non-zero when migrations fail

### DIFF
--- a/bin/tina4php
+++ b/bin/tina4php
@@ -554,8 +554,18 @@ DOCKERFILE;
             if (empty($result['applied']) && empty($result['errors'])) {
                 echo "No pending migrations.\n";
             }
+            // Migration failures must exit non-zero so CI/CD pipelines
+            // (Jenkins, GitHub Actions, etc.) actually fail when a
+            // migration breaks — otherwise the printed "Errors:" header
+            // sails past the deploy script and the build goes green.
+            // The exit happens AFTER the per-file summary so operators
+            // still see exactly which migration failed.
+            if (!empty($result['errors'])) {
+                exit(1);
+            }
         } else {
             echo "Migration class not available.\n";
+            exit(1);
         }
         break;
 

--- a/tests/CliMigrateExitCodeTest.php
+++ b/tests/CliMigrateExitCodeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the exit-code contract of `tina4php migrate`.
+ *
+ * Without these tests, the CLI would happily print "Errors:" then exit 0,
+ * letting CI/CD pipelines deploy code whose migrations didn't actually
+ * apply. The earlier (3.11.x — 3.12.13) handler did exactly that.
+ *
+ * The Migration class itself is covered in MigrationV3Test; this file
+ * specifically guards the CLI wrapper's exit-code mapping.
+ */
+class CliMigrateExitCodeTest extends TestCase
+{
+    private string $tmpDir;
+    private string $dbPath;
+    private string $binPath;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/tina4_cli_migrate_test_' . uniqid();
+        mkdir($this->tmpDir . '/migrations', 0755, true);
+        $this->dbPath = $this->tmpDir . '/test.db';
+        $this->binPath = realpath(__DIR__ . '/../bin/tina4php');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Run the CLI in the temp dir with DATABASE_URL pointed at our SQLite
+     * file, and return [exitCode, stdout]. Captures stderr too so failing
+     * runs surface useful detail.
+     */
+    private function runCli(): array
+    {
+        $env = ['DATABASE_URL' => 'sqlite:///' . $this->dbPath];
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $cmd = [PHP_BINARY, $this->binPath, 'migrate'];
+        $proc = proc_open($cmd, $descriptors, $pipes, $this->tmpDir, $env);
+        $this->assertIsResource($proc, 'failed to spawn CLI');
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+
+        return [$exitCode, $stdout . $stderr];
+    }
+
+    public function testCliExitsNonZeroWhenAMigrationErrors(): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/migrations/20240101000000_bad.sql',
+            'THIS IS NOT VALID SQL'
+        );
+
+        [$exitCode, $output] = $this->runCli();
+
+        $this->assertNotSame(0, $exitCode, 'CLI must exit non-zero on migration error; output was: ' . $output);
+        $this->assertStringContainsString('20240101000000_bad.sql', $output);
+    }
+
+    public function testCliExitsZeroWhenMigrationsSucceed(): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/migrations/20240101000000_create_users.sql',
+            'CREATE TABLE users (id INTEGER PRIMARY KEY)'
+        );
+
+        [$exitCode, $output] = $this->runCli();
+
+        $this->assertSame(0, $exitCode, 'CLI must exit 0 on success; output was: ' . $output);
+        $this->assertStringContainsString('Applied 1 migration', $output);
+    }
+
+    public function testCliExitsZeroWhenNoPendingMigrations(): void
+    {
+        // No migration files in the directory.
+        [$exitCode, $output] = $this->runCli();
+
+        $this->assertSame(0, $exitCode, 'CLI must exit 0 when nothing is pending; output was: ' . $output);
+        $this->assertStringContainsString('No pending migrations', $output);
+    }
+
+    public function testCliPartialFailureExitsNonZero(): void
+    {
+        // First migration OK; second is broken. The earlier handler would
+        // print "Applied 1 migration(s):" and "Errors:" then still exit 0.
+        file_put_contents(
+            $this->tmpDir . '/migrations/20240101000000_create_users.sql',
+            'CREATE TABLE users (id INTEGER PRIMARY KEY)'
+        );
+        file_put_contents(
+            $this->tmpDir . '/migrations/20240102000000_bad.sql',
+            'INVALID SQL STATEMENT'
+        );
+
+        [$exitCode, $output] = $this->runCli();
+
+        $this->assertNotSame(0, $exitCode, 'CLI must exit non-zero when ANY migration errors, even if some succeeded; output was: ' . $output);
+        $this->assertStringContainsString('Applied 1 migration', $output);
+        $this->assertStringContainsString('20240102000000_bad.sql', $output);
+    }
+}


### PR DESCRIPTION
## The bug

`tina4php migrate` prints an `Errors:` header (with one `x file: msg` line per failed migration) and then **exits 0**. CI/CD pipelines that rely on the CLI exit code (Jenkins, GitHub Actions, etc.) treat the broken deploy as successful — the build goes green, and the missing migration only surfaces later through schema bugs.

This was the root cause of a real production incident on one of the projects using Tina4 PHP: silent migration drift over a year of deploys.

## The fix

Two cases now exit `1`:

1. `Migration::migrate()` returned errors (any failed migration)
2. `\Tina4\Migration` isn't available (autoload broken)

The per-file summary still prints **before** the exit, so operators see exactly which migration failed.

### Diff

```diff
+            if (!empty($result['errors'])) {
+                exit(1);
+            }
         } else {
             echo "Migration class not available.\n";
+            exit(1);
         }
```

10 lines including the comment.

## Tests

New file `tests/CliMigrateExitCodeTest.php` (4 tests, 13 assertions) spawns the CLI via `proc_open` and pins the exit-code contract:

| Scenario | Expected exit code |
|---|---|
| All migrations succeed | `0` |
| Nothing pending | `0` |
| Single migration fails | non-zero |
| Partial failure (some applied, then one fails) | non-zero |

`tests/MigrationV3Test.php` still covers the underlying `Migration` class behaviour; this new file specifically guards the CLI wrapper's exit-code mapping. Both files pass.

## Local verification

```
$ vendor/bin/phpunit tests/CliMigrateExitCodeTest.php
OK (4 tests, 13 assertions)

$ vendor/bin/phpunit tests/MigrationV3Test.php
OK (30 tests, 79 assertions)
```

Full-suite shows 1 pre-existing failure in `RouteDiscoveryReloadTest.php:115` ("a .broken sentinel must be written for the failed file") on the unmodified `v3` tip — unrelated to this change, flagged separately.

## Why now

Discovered while auditing a downstream project's Jenkins pipeline: the deploy script's `if ! tina4php migrate; then exit 1; fi` was relied on as the safety net for an entire team's release process. The exit-code being wrong made the whole gate ornamental.