### PR TITLE
Fix FirebirdAdapter::execute() TypeError on parameterized DML (#121)

### DIFF
--- a/Tina4/Database/FirebirdAdapter.php
+++ b/Tina4/Database/FirebirdAdapter.php
@@ -234,8 +234,11 @@ class FirebirdAdapter implements DatabaseAdapter
                 throw new DatabaseException('Firebird execute() failed: ' . ($this->lastError ?? 'unknown error'));
             }
 
-            // If result is a resource (e.g. RETURNING), read first row for lastId
-            if ($result !== true) {
+            // Only a real result set (SELECT / RETURNING) carries a row to read for
+            // lastId. A bound-parameter INSERT/UPDATE/DELETE returns a non-true,
+            // non-resource value from ibase_execute(); ibase_fetch_assoc() on it raises
+            // a TypeError under PHP 8.x (the @ suppresses warnings, not Errors) — see #121.
+            if (is_resource($result)) {
                 $fetchFn = $this->fn . 'fetch_assoc';
                 $row = @$fetchFn($result);
                 if ($row !== false && $row !== null) {


### PR DESCRIPTION
Fixes #121.

### Problem
`FirebirdAdapter::execute()` reads the last-insert id for any result that is not strictly `=== true`, calling `ibase_fetch_assoc($result)`:

```php
// If result is a resource (e.g. RETURNING), read first row for lastId
if ($result !== true) {
    $fetchFn = $this->fn . 'fetch_assoc';
    $row = @$fetchFn($result);
    ...
}
```

`doExecute()`'s bound-parameter path runs `ibase_prepare()` + `ibase_execute()` and returns that value verbatim. For a **parameterized** `INSERT`/`UPDATE`/`DELETE`, `ibase_execute()` returns a non-`true`, non-resource value, so `ibase_fetch_assoc()` receives an int and raises:

```
ibase_fetch_assoc(): Argument #1 ($result) must be of type resource, int given
```

Under PHP 8 the `@` suppresses **warnings**, not **Errors**, so the `TypeError` propagates. The no-params path uses `ibase_query()` (returns `true` for DML) and is unaffected — so only the bound-parameter path breaks, which is the normal ORM / QueryBuilder / `$db->execute($sql, $params)` route. With the newer FAIL-LOUD `execute()`, this is a hard failure for every parameterized write (a `TypeError` is an `Error`, so `ORM::save()`'s `catch (\Exception)` doesn't catch it either).

### Fix
Guard the last-id fetch with `is_resource()` — only `SELECT` / `RETURNING` / `EXECUTE PROCEDURE` yield a result resource; DML returning `true`/int now flows straight to `commitDefault()`:

```diff
-            if ($result !== true) {
+            if (is_resource($result)) {
```

This also resolves the secondary effect where `commitDefault()` (which sits after the fetch) was skipped when the fetch threw — in autocommit mode the statement could be left uncommitted.

### Verification
This is PHP-specific (`ext-interbase` + PHP 8 `Error` semantics), so it can't be exercised without a live Firebird server. Following the existing convention (see `FirebirdReconnectTest` — live-Firebird behaviour is covered by manual QA, not unit tests), I've kept this to the one-line guard. Verified against a live Firebird (PHP 8.4.8, ext-interbase):

- Bound-parameter `UPDATE … WHERE <pk> = ?` → returns `true`, **no TypeError**.
- `RETURNING` / `SELECT` → still populate `lastId` correctly (resource path unchanged).

Happy to add a mocked-`ibase_*` regression test if you'd prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)