### PR TITLE
FirebirdAdapter: don't bind PHP null params (rewrite to literal NULL) — fixes #123

### DIFF
--- a/Tina4/Database/FirebirdAdapter.php
+++ b/Tina4/Database/FirebirdAdapter.php
@@ -624,6 +624,14 @@ class FirebirdAdapter implements DatabaseAdapter
             // ibase/fbird only speaks ? — translate :named from the ORM/QueryBuilder.
             [$sql, $params] = \Tina4\SqlTranslation::namedToPositional($sql, $params);
 
+            // ibase_execute()/fbird_execute() cannot reliably bind a PHP null — it
+            // fails building the XSQLDA ("Incorrect values within SQLDA structure —
+            // empty pointer to data at SQLVAR index N"), position/count dependent.
+            // Rewrite each null parameter to a literal NULL in the SQL and drop it
+            // from the bound set so no null is ever bound. Preserves true SQL NULL
+            // semantics and never touches a ? inside a string literal/comment. #123
+            [$sql, $params] = self::rewriteNullParamsToLiterals($sql, $params);
+
             $prepareFn = $this->fn . 'prepare';
             $executeFn = $this->fn . 'execute';
 
@@ -654,6 +662,48 @@ class FirebirdAdapter implements DatabaseAdapter
         }
 
         return $result;
+    }
+
+    /**
+     * Rewrite each NULL bound parameter to a literal `NULL` in the SQL and drop
+     * it from the positional value list. Works around the ibase/fbird driver
+     * mis-binding a PHP null (XSQLDA "empty pointer to data at SQLVAR index N").
+     *
+     * String literals ('' -escaped, Firebird style) and `--` line comments are
+     * skipped so a `?` inside them is never miscounted. NULL semantics are
+     * preserved — the column is still written as SQL NULL, just via a literal
+     * instead of a bound parameter.
+     *
+     * @param array<int, mixed> $params  positional params (post named-to-positional)
+     * @return array{0: string, 1: array<int, mixed>}
+     */
+    private static function rewriteNullParamsToLiterals(string $sql, array $params): array
+    {
+        if (!in_array(null, $params, true)) {
+            return [$sql, $params];
+        }
+
+        $index = 0;
+        $kept = [];
+        $rewritten = preg_replace_callback(
+            "/'(?:[^']|'')*'|--[^\n]*|\?/s",
+            static function (array $m) use (&$index, &$kept, $params): string {
+                if ($m[0] !== '?') {
+                    return $m[0]; // string literal / comment — preserved verbatim
+                }
+                $value = array_key_exists($index, $params) ? $params[$index] : null;
+                $index++;
+                if ($value === null) {
+                    return 'NULL';
+                }
+                $kept[] = $value;
+                return '?';
+            },
+            $sql
+        );
+
+        // Fail safe: if the PCRE engine bailed, leave the statement untouched.
+        return $rewritten === null ? [$sql, $params] : [$rewritten, $kept];
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -100,6 +100,7 @@
             <file>tests/ExecuteFailurePostgresTest.php</file>
             <file>tests/ExecuteRaisesTest.php</file>
             <file>tests/BooleanParamBindingTest.php</file>
+            <file>tests/FirebirdNullParamBindingTest.php</file>
             <file>tests/PlanListTest.php</file>
             <file>tests/SqlNormalizerTest.php</file>
             <file>tests/ServerLargeResponseTest.php</file>

--- a/tests/FirebirdNullParamBindingTest.php
+++ b/tests/FirebirdNullParamBindingTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Firebird: a bound PHP null must not be handed to ibase_execute()/fbird_execute()
+ * — the driver fails building the XSQLDA ("Incorrect values within SQLDA
+ * structure — empty pointer to data at SQLVAR index N"), position/count
+ * dependent, which broke every parameterised INSERT/UPDATE with a NULL column
+ * (and therefore ORM save() on any row leaving a nullable column null).
+ *
+ * FirebirdAdapter::rewriteNullParamsToLiterals() rewrites each null parameter to
+ * a literal NULL in the SQL and drops it from the bound set, so no null is ever
+ * bound (NULL semantics preserved). It is pure string logic — no server needed.
+ *
+ * Regression test for issue #123.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Database\FirebirdAdapter;
+
+class FirebirdNullParamBindingTest extends TestCase
+{
+    /** @param array<int, mixed> $params @return array{0:string,1:array} */
+    private function rewrite(string $sql, array $params): array
+    {
+        $m = new \ReflectionMethod(FirebirdAdapter::class, 'rewriteNullParamsToLiterals');
+        $m->setAccessible(true);
+        return $m->invoke(null, $sql, $params);
+    }
+
+    public function testNullParamsBecomeLiteralNullAndAreDropped(): void
+    {
+        [$sql, $params] = $this->rewrite(
+            'insert into t (a, b, c, d) values (?, ?, ?, ?)',
+            [1, null, 'x', null]
+        );
+        $this->assertSame('insert into t (a, b, c, d) values (?, NULL, ?, NULL)', $sql);
+        $this->assertSame([1, 'x'], array_values($params));
+    }
+
+    public function testQuestionMarkInsideStringLiteralIsNotAParameter(): void
+    {
+        [$sql, $params] = $this->rewrite(
+            "update t set note = 'is it? yes', a = ? where b = ?",
+            [null, 5]
+        );
+        $this->assertSame("update t set note = 'is it? yes', a = NULL where b = ?", $sql);
+        $this->assertSame([5], array_values($params));
+    }
+
+    public function testNoNullParamsLeavesStatementUnchanged(): void
+    {
+        $in = ['x', 5, 'y'];
+        [$sql, $params] = $this->rewrite('insert into t (a, b, c) values (?, ?, ?)', $in);
+        $this->assertSame('insert into t (a, b, c) values (?, ?, ?)', $sql);
+        $this->assertSame($in, array_values($params));
+    }
+
+    public function testAllNullParamsProduceNoBoundValues(): void
+    {
+        [$sql, $params] = $this->rewrite('insert into t (a, b) values (?, ?)', [null, null]);
+        $this->assertSame('insert into t (a, b) values (NULL, NULL)', $sql);
+        $this->assertSame([], $params);
+    }
+}


### PR DESCRIPTION
Fixes #123.

## Problem

`FirebirdAdapter::doExecute()` binds parameters by spreading them into
`ibase_execute()`/`fbird_execute()`. The driver **cannot reliably bind a PHP `null`** — it fails
building the XSQLDA with `Incorrect values within SQLDA structure — empty pointer to data at SQLVAR
index N`, and the failure is **position/parameter-count dependent** (any null in a multi-param INSERT;
a trailing null in a 2-param UPDATE; a lone null happens to work). This broke:

- every parameterised `INSERT`/`UPDATE` that binds a NULL value, and therefore
- **`ORM::save()` on any row leaving a nullable column null** — even on tables whose BEFORE-INSERT
  trigger assigns the id, because the adapter never gets past binding.

Firebird-specific — the PDO adapters (MySQL/Postgres/MSSQL/SQLite) bind null fine.

## Fix

In `doExecute()` (right after `namedToPositional()`), rewrite each `null` parameter to a **literal
`NULL`** in the SQL and drop it from the bound value list, so no null is ever handed to
`ibase_execute`. **NULL semantics are preserved** — the column is still written as SQL `NULL`, just via
a literal instead of a bound param. String literals (`''`-escaped, Firebird style) and `--` comments are
skipped so a `?` inside them is never miscounted; a PCRE failure falls back to the original statement.

## Tests

`tests/FirebirdNullParamBindingTest.php` — pure string-logic unit tests via reflection (no server), sits
next to `BooleanParamBindingTest`:

```
OK (4 tests, 8 assertions)
```

covering: nulls → literal `NULL` + dropped from binds; a `?` inside a string literal is not treated as a
parameter; no-null statements unchanged; all-null → no bound values. The end-to-end behaviour (a 14-column
ledger INSERT with nulls now commits, columns stored as real `NULL`) was verified against a live Firebird
(details in #123).

## Notes

Pairs with #121 (`ibase_fetch_assoc` on a non-result DML statement) — ORM `save()` on Firebird needs both.
`composer.lock` intentionally not touched.
