### PR TITLE
Migration: honour SET TERM terminator directives in splitStatements (all adapters)

### DIFF
--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -928,15 +928,18 @@ class Migration
     }
 
     /**
-     * If $statement is a Firebird-style `SET TERM <new> <current>` directive,
-     * return the <new> terminator; otherwise null.
+     * Parse a `SET TERM <new> <current>` statement-terminator directive.
      *
-     * `SET TERM` is a client-side script directive (isql / FlameRobin / gfix),
-     * NOT SQL the engine runs. Honouring it lets a migration switch the
-     * statement terminator so a PSQL body — a trigger, stored procedure or
-     * EXECUTE BLOCK, whose inner statements are themselves ';'-terminated — is
-     * kept as ONE statement instead of being split apart on those inner ';'.
-     * The terminator may be multiple characters (e.g. `SET TERM !! ;`).
+     * `SET TERM` is a script-level directive (recognised by isql and other
+     * InterBase/Firebird tooling, not run by the engine) that changes the
+     * terminator separating statements. Recognising it lets a statement whose
+     * own body contains the default `;` terminator — a trigger, stored
+     * procedure or `EXECUTE BLOCK` — be kept intact rather than split on those
+     * inner `;`. The terminator may be more than one character (e.g. `!!`).
+     *
+     * @param string $statement A single, already-trimmed statement.
+     * @return string|null The new terminator, or null when $statement is not a
+     *                     `SET TERM` directive.
      */
     private static function parseSetTerm(string $statement): ?string
     {
@@ -946,6 +949,19 @@ class Migration
         return null;
     }
 
+    /**
+     * Split a migration script into its individual statements.
+     *
+     * Statements are separated on the active terminator (the configured
+     * delimiter, `;` by default), while dollar-quoted (`$$`) and slash-quoted
+     * (`//`) blocks, quoted strings/identifiers, and line/block comments are
+     * kept intact. A `SET TERM` directive switches the active terminator so a
+     * statement whose body contains the default terminator survives as one.
+     *
+     * @param string $sql The raw migration script.
+     * @return array<int, string> The trimmed statements, in order, with
+     *                            terminators and `SET TERM` directives removed.
+     */
     private function splitStatements(string $sql): array
     {
         // Normalize smart/curly quotes to straight ASCII first, so SQL pasted
@@ -961,11 +977,11 @@ class Migration
         $inDollarBlock = false;
         $inSlashBlock = false;
 
-        // Active statement terminator. Starts as the configured delimiter, but a
-        // `SET TERM <new> <current>` directive (the Firebird PSQL idiom) can
-        // switch it mid-file so trigger / procedure / EXECUTE BLOCK bodies —
-        // whose inner statements are ';'-terminated — are not split apart.
-        // Multi-character terminators (e.g. `!!`) are supported.
+        // Active statement terminator. Starts as the configured delimiter; a
+        // `SET TERM <new> <current>` directive can switch it mid-script so a
+        // statement whose own body contains the default terminator (trigger /
+        // procedure / EXECUTE BLOCK) stays intact. Multi-character terminators
+        // (e.g. `!!`) are supported.
         $delimiter = $this->delimiter;
 
         while ($i < $len) {

--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -890,16 +890,6 @@ class Migration
     }
 
     /**
-     * Split SQL content into individual statements, properly handling:
-     *   - $$ delimited stored procedure/function blocks
-     *   - // delimited blocks
-     *   - Block comments: /* ... * /
-     *   - Line comments: -- ...
-     *   - Quoted strings (don't split on ; inside quotes)
-     *
-     * @return array<string>
-     */
-    /**
      * Normalize smart/curly quotes back to straight ASCII quotes.
      *
      * Editors, word processors, docs and chat apps silently convert a straight

--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -927,6 +927,25 @@ class Migration
         ]);
     }
 
+    /**
+     * If $statement is a Firebird-style `SET TERM <new> <current>` directive,
+     * return the <new> terminator; otherwise null.
+     *
+     * `SET TERM` is a client-side script directive (isql / FlameRobin / gfix),
+     * NOT SQL the engine runs. Honouring it lets a migration switch the
+     * statement terminator so a PSQL body — a trigger, stored procedure or
+     * EXECUTE BLOCK, whose inner statements are themselves ';'-terminated — is
+     * kept as ONE statement instead of being split apart on those inner ';'.
+     * The terminator may be multiple characters (e.g. `SET TERM !! ;`).
+     */
+    private static function parseSetTerm(string $statement): ?string
+    {
+        if (preg_match('/^SET\s+TERM\s+(\S+)$/i', trim($statement), $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
     private function splitStatements(string $sql): array
     {
         // Normalize smart/curly quotes to straight ASCII first, so SQL pasted
@@ -941,6 +960,13 @@ class Migration
         $i = 0;
         $inDollarBlock = false;
         $inSlashBlock = false;
+
+        // Active statement terminator. Starts as the configured delimiter, but a
+        // `SET TERM <new> <current>` directive (the Firebird PSQL idiom) can
+        // switch it mid-file so trigger / procedure / EXECUTE BLOCK bodies —
+        // whose inner statements are ';'-terminated — are not split apart.
+        // Multi-character terminators (e.g. `!!`) are supported.
+        $delimiter = $this->delimiter;
 
         while ($i < $len) {
             // Check for $$ delimiter (toggle in/out of dollar-quoted block)
@@ -1030,14 +1056,22 @@ class Migration
                 continue;
             }
 
-            // Statement delimiter
-            if ($sql[$i] === $this->delimiter) {
+            // Statement delimiter (multi-character aware). A `SET TERM`
+            // directive is consumed (never emitted as SQL) and switches the
+            // active terminator; every other completed statement is collected.
+            $dlen = strlen($delimiter);
+            if ($dlen > 0 && $sql[$i] === $delimiter[0] && substr($sql, $i, $dlen) === $delimiter) {
                 $trimmed = trim($current);
                 if ($trimmed !== '') {
-                    $statements[] = $trimmed;
+                    $newTerm = self::parseSetTerm($trimmed);
+                    if ($newTerm !== null) {
+                        $delimiter = $newTerm;
+                    } else {
+                        $statements[] = $trimmed;
+                    }
                 }
                 $current = '';
-                $i++;
+                $i += $dlen;
                 continue;
             }
 
@@ -1045,9 +1079,10 @@ class Migration
             $i++;
         }
 
-        // Don't forget the last statement (may not end with delimiter)
+        // Don't forget the last statement (may not end with delimiter). A
+        // trailing `SET TERM` directive is a no-op — consume it, don't emit it.
         $trimmed = trim($current);
-        if ($trimmed !== '') {
+        if ($trimmed !== '' && self::parseSetTerm($trimmed) === null) {
             $statements[] = $trimmed;
         }
 

--- a/tests/MigrationFootgunsTest.php
+++ b/tests/MigrationFootgunsTest.php
@@ -174,6 +174,90 @@ class MigrationFootgunsTest extends TestCase
         $this->assertSame($sql, self::staticInvoke('normalizeQuotes', [$sql]));
     }
 
+    // ── SET TERM switches the delimiter so PSQL bodies survive ──────────
+    //
+    // Firebird triggers / procedures / EXECUTE BLOCK have ';'-terminated inner
+    // statements. Run under the DEFAULT ';' runner (auto-migrate) they used to be
+    // shredded on those inner ';'. A `SET TERM <new> <cur>` directive — the
+    // universal isql/FlameRobin/gfix idiom — switches the terminator so the body
+    // stays one statement.
+
+    public function testSetTermKeepsFirebirdTriggerBodyIntact(): void
+    {
+        $m = $this->newMigration(new SQLite3Adapter(':memory:'));
+        $sql = "SET TERM ^ ;\n"
+            . "CREATE OR ALTER TRIGGER t_bi FOR t ACTIVE BEFORE INSERT AS\n"
+            . "BEGIN\n"
+            . "  IF (NEW.id IS NULL) THEN NEW.id = GEN_ID(GEN_T, 1);\n"
+            . "END^\n"
+            . "SET TERM ; ^";
+
+        $stmts = $this->invoke($m, 'splitStatements', [$sql]);
+
+        $this->assertCount(1, $stmts, 'trigger body was split on its inner ";"');
+        $this->assertStringStartsWith('CREATE OR ALTER TRIGGER', $stmts[0]);
+        $this->assertStringEndsWith('END', $stmts[0]);
+        $this->assertStringContainsString('NEW.id = GEN_ID(GEN_T, 1);', $stmts[0]);
+    }
+
+    public function testSetTermDirectivesAreConsumedNotEmitted(): void
+    {
+        $m = $this->newMigration(new SQLite3Adapter(':memory:'));
+        $sql = "SET TERM ^ ;\nEXECUTE BLOCK AS BEGIN a; b; END^\nSET TERM ; ^";
+
+        $stmts = $this->invoke($m, 'splitStatements', [$sql]);
+
+        $this->assertCount(1, $stmts);
+        foreach ($stmts as $s) {
+            $this->assertStringNotContainsString('SET TERM', $s, 'SET TERM leaked as a SQL statement');
+        }
+    }
+
+    public function testSetTermRestoresPreviousDelimiter(): void
+    {
+        $m = $this->newMigration(new SQLite3Adapter(':memory:'));
+        // After `SET TERM ; ^`, plain ';' splitting resumes.
+        $sql = "CREATE TABLE a (id INT);\n"
+            . "SET TERM ^ ;\n"
+            . "CREATE TRIGGER a_bi FOR a AS BEGIN NEW.id = 1; END^\n"
+            . "SET TERM ; ^\n"
+            . "INSERT INTO a VALUES (1);\nUPDATE a SET id = 2;";
+
+        $stmts = $this->invoke($m, 'splitStatements', [$sql]);
+
+        $this->assertCount(4, $stmts, 'delimiter not restored to ";" after the block');
+        $this->assertStringStartsWith('CREATE TABLE', $stmts[0]);
+        $this->assertStringStartsWith('CREATE TRIGGER', $stmts[1]);
+        $this->assertStringStartsWith('INSERT INTO', $stmts[2]);
+        $this->assertStringStartsWith('UPDATE', $stmts[3]);
+    }
+
+    public function testSetTermSupportsMultiCharTerminator(): void
+    {
+        $m = $this->newMigration(new SQLite3Adapter(':memory:'));
+        $sql = "SET TERM !! ;\nCREATE TRIGGER t FOR x AS BEGIN NEW.a = 1; END!!\nSET TERM ; !!";
+
+        $stmts = $this->invoke($m, 'splitStatements', [$sql]);
+
+        $this->assertCount(1, $stmts);
+        $this->assertStringNotContainsString('!!', $stmts[0]);
+        $this->assertStringNotContainsString('SET TERM', $stmts[0]);
+    }
+
+    public function testPlainSemicolonUnaffectedBySetTermSupport(): void
+    {
+        $m = $this->newMigration(new SQLite3Adapter(':memory:'));
+        // No SET TERM → ordinary ';' splitting, behaviour unchanged.
+        $sql = "CREATE TABLE a (id INT);\nINSERT INTO a VALUES (1);\nUPDATE a SET id = 2;";
+
+        $stmts = $this->invoke($m, 'splitStatements', [$sql]);
+
+        $this->assertCount(3, $stmts);
+        foreach ($stmts as $s) {
+            $this->assertFalse(str_ends_with($s, ';'), 'statement kept its trailing ";"');
+        }
+    }
+
     // ── [8] numeric-aware discovery order ───────────────────────────────
 
     public function testGetMigrationFilesIsNumericAware(): void


### PR DESCRIPTION
## What this changes

`Migration::splitStatements()` — shared by every database adapter — now
recognises the `SET TERM <new> <current>` statement-terminator directive. While
a `SET TERM` block is in effect the active terminator is switched, so a single
statement whose own body contains the default `;` terminator survives as one
statement instead of being shredded on those inner `;`.

This is a general splitter capability, not adapter-specific:

- The active terminator is tracked in a local var (was `$this->delimiter`).
- A `SET TERM` directive switches it and is **consumed** — never emitted as SQL
  (it is a client-side script directive, not engine SQL).
- Matching is multi-character-aware (`SET TERM !! ;`).
- **No-op for any script without `SET TERM`** — it splits exactly as before, so
  Postgres / MySQL / SQLite / MSSQL migrations are unaffected.

## Motivating case (Firebird PSQL)

A Firebird trigger / stored procedure / `EXECUTE BLOCK` body has `;`-terminated
inner statements and Firebird *requires* them, so under the default `;` runner
(which `autoMigrateOnStartup()` always uses) the body was split into invalid
fragments and the migration could not auto-run. `SET TERM` is the universal isql
/ FlameRobin / gfix idiom for exactly this, and the same file now also runs
verbatim in isql:

```sql
SET TERM ^ ;
CREATE OR ALTER TRIGGER t_bi FOR t ACTIVE BEFORE INSERT AS
BEGIN
  IF (NEW.id IS NULL) THEN NEW.id = GEN_ID(GEN_T, 1);
END^
SET TERM ; ^
```

## Tests

5 cases in `tests/MigrationFootgunsTest.php` against a real
`SQLite3Adapter(':memory:')` (no mocks): trigger-body-intact,
SET-TERM-consumed-not-emitted, delimiter-restore-after-block, multi-char
terminator, and **plain-`;` unaffected** (the no-op guarantee for other
adapters). Also proven end-to-end against a throwaway real Firebird 4.0 DB via
isql: the `SET TERM` trigger migration applies and the trigger auto-assigns ids.

## Parity

PHP only in this PR — port to tina4-python (reference), tina4-ruby,
tina4-nodejs still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)