### PR TITLE
feat(firebird): add pdo_firebird adapter, auto-preferred over deprecated ext-interbase

### DIFF
--- a/Tina4/Database/Database.php
+++ b/Tina4/Database/Database.php
@@ -1497,12 +1497,7 @@ class Database implements DatabaseAdapter
             PostgresAdapter::class => new PostgresAdapter($url, $autoCommit, username: $username, password: $password),
             MySQLAdapter::class => new MySQLAdapter($url, username: $username, password: $password, autoCommit: $autoCommit),
             MSSQLAdapter::class => new MSSQLAdapter($url, username: $username, password: $password, autoCommit: $autoCommit),
-            FirebirdAdapter::class => new FirebirdAdapter(
-                $url,
-                username: $username !== '' ? $username : (isset($parts['user']) ? urldecode($parts['user']) : 'SYSDBA'),
-                password: $password !== '' ? $password : (isset($parts['pass']) ? urldecode($parts['pass']) : 'masterkey'),
-                autoCommit: $autoCommit,
-            ),
+            FirebirdAdapter::class => self::createFirebirdAdapter($url, $parts, $username, $password, $autoCommit),
             MongoDBAdapter::class => new MongoDBAdapter(
                 $url,
                 username: $username,
@@ -1517,5 +1512,38 @@ class Database implements DatabaseAdapter
                 autoCommit: $autoCommit,
             ),
         };
+    }
+
+    /**
+     * Choose and construct the Firebird adapter.
+     *
+     * Prefers the modern **pdo_firebird** driver ({@see PdoFirebirdAdapter})
+     * when it is available — it reads Firebird 4+ `INT128`/`DECFLOAT` results
+     * (e.g. `SUM()` over an exact numeric) that the deprecated ext-interbase
+     * ({@see FirebirdAdapter}) cannot, crashing the process on those. Falls back
+     * to the legacy ibase adapter when pdo_firebird is not loaded.
+     *
+     * Override the choice with `TINA4_FIREBIRD_DRIVER`:
+     *   - `pdo` / `pdo_firebird` → force the PDO adapter
+     *   - `ibase` / `interbase`  → force the legacy ibase adapter
+     *   - unset / anything else  → auto (prefer PDO when the extension is loaded)
+     *
+     * @param array<string, mixed> $parts parse_url() components of $url
+     */
+    private static function createFirebirdAdapter(string $url, array $parts, string $username, string $password, ?bool $autoCommit): DatabaseAdapter
+    {
+        $user = $username !== '' ? $username : (isset($parts['user']) ? urldecode($parts['user']) : 'SYSDBA');
+        $pass = $password !== '' ? $password : (isset($parts['pass']) ? urldecode($parts['pass']) : 'masterkey');
+
+        $pref = strtolower((string) (\Tina4\DotEnv::getEnv('TINA4_FIREBIRD_DRIVER') ?? ''));
+        $usePdo = match ($pref) {
+            'pdo', 'pdo_firebird' => true,
+            'ibase', 'interbase'  => false,
+            default => extension_loaded('pdo_firebird'),
+        };
+
+        return $usePdo
+            ? new PdoFirebirdAdapter($url, username: $user, password: $pass, autoCommit: $autoCommit)
+            : new FirebirdAdapter($url, username: $user, password: $pass, autoCommit: $autoCommit);
     }
 }

--- a/Tina4/Database/PdoFirebirdAdapter.php
+++ b/Tina4/Database/PdoFirebirdAdapter.php
@@ -1,0 +1,398 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Database;
+
+/**
+ * Firebird database adapter using PHP's built-in **pdo_firebird** driver.
+ *
+ * The legacy {@see FirebirdAdapter} talks to the C API through the deprecated
+ * ext-interbase (`ibase_*`) extension, which was removed from PHP core in 7.4
+ * and is unmaintained. Its build ships compiled against the Firebird 3 API, so
+ * on a Firebird 4+ server any aggregate result that the engine widens to the
+ * new 128-bit type (`SUM()`/`AVG()` over an exact numeric → `INT128`, or a
+ * `DECFLOAT`) walks off the end of the extension's type table and hard-crashes
+ * the PHP process (`0xC0000005` / `SIGSEGV`) — a native fault no `try/catch`
+ * can trap. `pdo_firebird` (a first-class, maintained core driver) understands
+ * the Firebird 4 types and reads an `INT128`/`DECFLOAT` back as a string, so it
+ * is the correct modern transport.
+ *
+ * This adapter **extends** `FirebirdAdapter` deliberately: the framework
+ * dispatches Firebird-specific behaviour (the `GEN_ID` generator path in
+ * `Database::getNextId()`, the Firebird DDL branch in `Migration`, and
+ * `ORM`/`Migration` dialect detection) via `instanceof FirebirdAdapter`.
+ * Sharing the type identity keeps every one of those sites working unchanged.
+ * The entire I/O surface (connect, query, fetch, execute, transactions) is
+ * overridden here to run through PDO; the parent's ibase-only methods are never
+ * reached. The `#121`/`#123` ibase workarounds (fetch_assoc-on-int TypeError,
+ * the null-bind XSQLDA fault) simply do not exist on the PDO path.
+ *
+ * Firebird specifics (unchanged from the parent):
+ *   - No LIMIT/OFFSET — uses `ROWS X TO Y`
+ *   - Auto-increment via generators (`GEN_ID(gen, 1)`) — see Database::getNextId
+ *   - RETURNING is supported (Firebird 2.0+)
+ */
+class PdoFirebirdAdapter extends FirebirdAdapter
+{
+    /**
+     * Live PDO handle. Named distinctly from the parent's ibase `$db` resource
+     * so the two transports never alias — this adapter only ever touches PDO.
+     */
+    private ?\PDO $pdo = null;
+
+    /**
+     * This class's own error/state. The parent declares private members of the
+     * same purpose for its ibase path; because every state-touching method is
+     * overridden here, only these are ever read or written on a PDO instance.
+     */
+    private ?string $lastError = null;
+    private bool $autoCommit;
+    private int|string $lastId = 0;
+
+    private string $connString;
+    private string $dbUser;
+    private string $dbPass;
+    private string $dbCharset;
+
+    /**
+     * @param string    $connectionString URL: "firebird://user:pass@host:port/path/to/db.fdb" or a path
+     * @param string    $username         Username (default: SYSDBA)
+     * @param string    $password         Password (default: masterkey)
+     * @param string    $charset          Character set (default: UTF8)
+     * @param bool|null $autoCommit       Whether a standalone write commits on its own
+     */
+    public function __construct(
+        string $connectionString,
+        string $username = 'SYSDBA',
+        string $password = 'masterkey',
+        string $charset = 'UTF8',
+        ?bool $autoCommit = null,
+    ) {
+        // NB: intentionally does NOT call parent::__construct() — the parent
+        // constructor requires the ibase extension and opens an ibase handle.
+        if (!extension_loaded('pdo_firebird') || !in_array('firebird', \PDO::getAvailableDrivers(), true)) {
+            throw new \RuntimeException(
+                'PdoFirebirdAdapter requires the pdo_firebird PHP extension (PDO Firebird driver). '
+                . 'Enable it with extension=pdo_firebird in php.ini.'
+            );
+        }
+
+        $this->connString = $connectionString;
+        $this->dbUser = $username;
+        $this->dbPass = $password;
+        $this->dbCharset = $charset;
+
+        $envAutoCommit = \Tina4\DotEnv::getEnv('TINA4_AUTOCOMMIT');
+        $this->autoCommit = $autoCommit ?? ($envAutoCommit !== null ? filter_var($envAutoCommit, FILTER_VALIDATE_BOOLEAN) : true);
+        $this->open();
+    }
+
+    public function open(): void
+    {
+        if ($this->pdo !== null) {
+            return;
+        }
+
+        $params = $this->parsePdoConnection($this->connString);
+
+        // PDO Firebird DSN: firebird:dbname=HOST/PORT:DATABASE;charset=UTF8
+        // (host/port omitted for a local/embedded database).
+        $dbSpec = $params['database'];
+        if ($params['host'] !== '') {
+            $port = $params['port'] > 0 ? $params['port'] : 3050;
+            $dbSpec = "{$params['host']}/{$port}:{$params['database']}";
+        }
+        $dsn = "firebird:dbname={$dbSpec};charset={$this->dbCharset}";
+
+        try {
+            $this->pdo = new \PDO($dsn, $params['username'], $params['password'], [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ]);
+        } catch (\PDOException $e) {
+            $this->lastError = $e->getMessage();
+            throw new \RuntimeException("PdoFirebirdAdapter: Failed to connect: {$this->lastError}");
+        }
+    }
+
+    public function close(): void
+    {
+        // PDO closes the connection when the handle is released.
+        $this->pdo = null;
+    }
+
+    public function query(string $sql, array $params = []): array
+    {
+        $this->ensureOpen();
+        $this->lastError = null;
+
+        try {
+            $stmt = $this->runStatement($sql, $params);
+
+            // Non-result statements (DDL, DML without RETURNING) have no columns.
+            if ($stmt->columnCount() === 0) {
+                return [];
+            }
+
+            $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+            return array_map([$this, 'cleanRow'], $rows);
+        } catch (\PDOException $e) {
+            // Read path swallows to [] and records the cause — parity with the
+            // ibase adapter's query() (fetch()/fetchOne()/execute() FAIL LOUD).
+            $this->lastError = $e->getMessage();
+            return [];
+        }
+    }
+
+    public function fetch(string $sql, array $params = [], int $limit = 100, int $offset = 0): array
+    {
+        $this->ensureOpen();
+        $this->lastError = null;
+        // Strip trailing `;` before the COUNT(*) wrap + ROWS pagination.
+        $sql = self::stripTrailingSemicolons($sql);
+
+        // FAIL LOUD (DB-contract A): the COUNT probe is best-effort (its own
+        // query() call, its failure only defaults total to 0), but the MAIN
+        // paginated query RAISES on a bad statement rather than swallowing to [].
+        $total = 0;
+        $countResult = $this->query("SELECT COUNT(*) AS total FROM ({$sql})", $params);
+        if ($this->lastError === null) {
+            $total = (int) ($countResult[0]['TOTAL'] ?? $countResult[0]['total'] ?? 0);
+        }
+
+        $this->lastError = null;
+        if ($limit <= 0) {
+            $pagedSql = $sql;
+        } else {
+            $startRow = $offset + 1;
+            $endRow = $offset + $limit;
+            $pagedSql = "{$sql} ROWS {$startRow} TO {$endRow}";
+        }
+        $data = $this->query($pagedSql, $params);
+        if ($this->lastError !== null) {
+            throw new DatabaseException('Firebird fetch() failed: ' . $this->lastError);
+        }
+
+        return [
+            'data' => $data,
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ];
+    }
+
+    public function fetchOne(string $sql, array $params = []): ?array
+    {
+        $sql = self::stripTrailingSemicolons($sql);
+        // FAIL LOUD (DB-contract A): a non-null lastError after query() means the
+        // statement failed — raise instead of returning null ("no row").
+        $rows = $this->query($sql, $params);
+        if ($this->lastError !== null) {
+            throw new DatabaseException('Firebird fetchOne() failed: ' . $this->lastError);
+        }
+        return $rows[0] ?? null;
+    }
+
+    public function execute(string $sql, array $params = []): bool|DatabaseResult
+    {
+        $this->ensureOpen();
+        $this->lastError = null;
+
+        try {
+            $stmt = $this->runStatement($sql, $params);
+
+            // A real result set (SELECT / RETURNING / EXECUTE PROCEDURE) carries a
+            // row we can read for lastId. A plain INSERT/UPDATE/DELETE has none.
+            if ($stmt->columnCount() > 0) {
+                $row = $stmt->fetch(\PDO::FETCH_NUM);
+                if (is_array($row) && array_key_exists(0, $row)) {
+                    $first = $row[0];
+                    $this->lastId = is_string($first) ? rtrim($first) : $first;
+                }
+            }
+
+            return true;
+        } catch (\PDOException $e) {
+            // FAIL LOUD: capture the cause on error() AND raise (parity with the
+            // Python master and with fetch()/fetchOne()).
+            $this->lastError = $e->getMessage();
+            throw new DatabaseException('Firebird execute() failed: ' . $this->lastError, 0, $e);
+        }
+    }
+
+    public function lastInsertId(): int|string
+    {
+        return $this->lastId;
+    }
+
+    public function startTransaction(): void
+    {
+        $this->ensureOpen();
+        if (!$this->pdo->inTransaction()) {
+            $this->pdo->beginTransaction();
+        }
+    }
+
+    public function commit(): void
+    {
+        $this->ensureOpen();
+        if ($this->pdo->inTransaction()) {
+            $this->pdo->commit();
+        }
+    }
+
+    public function rollback(): void
+    {
+        $this->ensureOpen();
+        try {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+        } catch (\PDOException $e) {
+            $this->lastError = $e->getMessage();
+        }
+    }
+
+    public function error(): ?string
+    {
+        return $this->lastError;
+    }
+
+    /**
+     * The underlying PDO handle (parity with the parent's getConnection()).
+     */
+    public function getConnection(): mixed
+    {
+        return $this->pdo;
+    }
+
+    public function getDatabase(): string
+    {
+        return $this->connString;
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────
+
+    private function ensureOpen(): void
+    {
+        if ($this->pdo === null) {
+            $this->open();
+        }
+    }
+
+    /**
+     * Prepare + execute a statement, with a one-shot reconnect-and-retry on a
+     * dead connection (idle Firebird sockets die behind NAT / server idle
+     * timeout / Docker network rotation). Skipped inside an explicit
+     * transaction — atomicity beats resilience; the caller handles rollback.
+     *
+     * @param array<int|string, mixed> $params
+     */
+    private function runStatement(string $sql, array $params): \PDOStatement
+    {
+        try {
+            return $this->prepareAndExecute($sql, $params);
+        } catch (\PDOException $e) {
+            if (!FirebirdAdapter::isDeadConnection($e->getMessage()) || $this->pdo->inTransaction()) {
+                throw $e;
+            }
+            $this->reconnect();
+            return $this->prepareAndExecute($sql, $params);
+        }
+    }
+
+    /**
+     * Single-attempt prepare + bind + execute.
+     *
+     * @param array<int|string, mixed> $params
+     */
+    private function prepareAndExecute(string $sql, array $params): \PDOStatement
+    {
+        if (!empty($params)) {
+            // Normalise :named placeholders (ORM/QueryBuilder) to positional ?,
+            // matching the parent — PDO Firebird then binds by position.
+            [$sql, $params] = \Tina4\SqlTranslation::namedToPositional($sql, $params);
+        }
+        // Firebird has no native boolean (BooleanField is INTEGER); bind PHP
+        // booleans as 1/0. PDO binds a null param as SQL NULL natively — so the
+        // ibase #123 null-rewrite is not needed here.
+        $values = self::normalizeBoolParams(array_values($params), nativeBoolean: false);
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($values);
+        return $stmt;
+    }
+
+    /**
+     * Trim CHAR padding from strings and materialise BLOB streams into bytes —
+     * matching the ibase adapter's query() row cleaning so callers see the same
+     * shapes regardless of transport.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function cleanRow(array $row): array
+    {
+        foreach ($row as $key => $value) {
+            if (is_resource($value)) {
+                // pdo_firebird returns BLOB columns as stream resources.
+                $row[$key] = stream_get_contents($value) ?: '';
+            } elseif (is_string($value)) {
+                $row[$key] = rtrim($value);
+            }
+        }
+        return $row;
+    }
+
+    /**
+     * Force-close the stale handle and reopen. Idempotent.
+     */
+    private function reconnect(): void
+    {
+        $this->pdo = null;
+        $this->open();
+    }
+
+    /**
+     * Parse a connection URL (or path) into host/port/username/password/database.
+     *
+     * Mirrors the parent's private parseConnection(): honours the
+     * TINA4_DATABASE_FIREBIRD_PATH override and normalises the URL path into a
+     * Firebird database identifier via the parent's public static helper.
+     *
+     * @return array{host: string, port: int, username: string, password: string, database: string}
+     */
+    private function parsePdoConnection(string $input): array
+    {
+        $envOverride = \Tina4\DotEnv::getEnv('TINA4_DATABASE_FIREBIRD_PATH');
+
+        if (str_contains($input, '://')) {
+            $parts = parse_url($input);
+            $rawPath = $parts['path'] ?? '';
+            $database = ($envOverride !== null && $envOverride !== '')
+                ? $envOverride
+                : FirebirdAdapter::normalizeDbIdentifier($rawPath);
+            return [
+                'host' => $parts['host'] ?? '',
+                'port' => (int) ($parts['port'] ?? 3050),
+                'username' => isset($parts['user']) ? urldecode($parts['user']) : $this->dbUser,
+                'password' => isset($parts['pass']) ? urldecode($parts['pass']) : $this->dbPass,
+                'database' => $database,
+            ];
+        }
+
+        return [
+            'host' => '',
+            'port' => 3050,
+            'username' => $this->dbUser,
+            'password' => $this->dbPass,
+            'database' => ($envOverride !== null && $envOverride !== '') ? $envOverride : $input,
+        ];
+    }
+}

--- a/tests/PdoFirebirdAdapterTest.php
+++ b/tests/PdoFirebirdAdapterTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * PdoFirebirdAdapter — the modern pdo_firebird transport for Firebird.
+ *
+ * Motivating regression: on Firebird 4 the engine widens SUM()/AVG() over an
+ * exact-numeric column to the new 128-bit INT128 type. The deprecated
+ * ext-interbase driver (php_interbase, built against the Firebird 3 API) cannot
+ * marshal that result descriptor and hard-crashes the PHP process (SIGSEGV /
+ * 0xC0000005) — a native fault no try/catch can trap. The maintained core
+ * pdo_firebird driver reads INT128/DECFLOAT back as a string, so the aggregate
+ * returns normally. This adapter runs Firebird over pdo_firebird while keeping
+ * the FirebirdAdapter type identity the framework dispatches on.
+ *
+ * Live tests need a Firebird server (no mocks): gated on the pdo_firebird
+ * extension AND TINA4_TEST_FIREBIRD_URL; otherwise skipped.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Database\Database;
+use Tina4\Database\FirebirdAdapter;
+use Tina4\Database\PdoFirebirdAdapter;
+
+class PdoFirebirdAdapterTest extends TestCase
+{
+    private ?PdoFirebirdAdapter $db = null;
+    private string $table = 'T4_PDO_FB_TEST';
+    private string $gen = 'GEN_T4_PDO_FB_TEST_ID';
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_firebird')) {
+            $this->markTestSkipped('pdo_firebird extension not installed');
+        }
+        if (!getenv('TINA4_TEST_FIREBIRD_URL')) {
+            $this->markTestSkipped('Set TINA4_TEST_FIREBIRD_URL to run live PdoFirebirdAdapter tests (e.g. firebird://SYSDBA:masterkey@localhost:3050/path/to/test.fdb)');
+        }
+        $this->db = new PdoFirebirdAdapter(getenv('TINA4_TEST_FIREBIRD_URL'));
+        $this->dropFixtures();
+        $this->db->execute(
+            "CREATE TABLE {$this->table} (ID INTEGER NOT NULL PRIMARY KEY, NAME VARCHAR(50), AMOUNT NUMERIC(18,2))"
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            $this->dropFixtures();
+            $this->db->close();
+            $this->db = null;
+        }
+    }
+
+    private function dropFixtures(): void
+    {
+        // DROP GENERATOR is FB2, DROP SEQUENCE is FB3+ — try both; either the
+        // table/generator exists (dropped) or it doesn't (harmless throw).
+        foreach (["DROP TABLE {$this->table}", "DROP SEQUENCE {$this->gen}", "DROP GENERATOR {$this->gen}"] as $ddl) {
+            try {
+                $this->db->execute($ddl);
+            } catch (\Throwable) {
+                // fixture not present
+            }
+        }
+    }
+
+    /** Set (or clear with null) the driver-selection override the factory reads. */
+    private function setDriver(?string $value): void
+    {
+        if ($value === null) {
+            unset($_ENV['TINA4_FIREBIRD_DRIVER']);
+            putenv('TINA4_FIREBIRD_DRIVER');
+        } else {
+            $_ENV['TINA4_FIREBIRD_DRIVER'] = $value;
+            putenv("TINA4_FIREBIRD_DRIVER={$value}");
+        }
+    }
+
+    public function testConnectsAndKeepsFirebirdIdentity(): void
+    {
+        $this->assertInstanceOf(\PDO::class, $this->db->getConnection());
+        // Extends FirebirdAdapter so every `instanceof FirebirdAdapter` dispatch
+        // (Database::getNextId generator path, Migration DDL branch, dialect
+        // detection) keeps working on the PDO transport.
+        $this->assertInstanceOf(FirebirdAdapter::class, $this->db);
+        $this->assertIsArray($this->db->getTables());
+    }
+
+    public function testFactoryAutoSelectsPdoWhenExtensionLoaded(): void
+    {
+        $this->setDriver(null); // auto
+        $db = Database::create(getenv('TINA4_TEST_FIREBIRD_URL'));
+        $this->assertInstanceOf(PdoFirebirdAdapter::class, $db->getAdapter());
+        $db->close();
+    }
+
+    public function testFactoryHonoursIbaseOverride(): void
+    {
+        if (!function_exists('ibase_connect') && !function_exists('fbird_connect')) {
+            $this->markTestSkipped('ext-interbase not installed — cannot build the legacy adapter');
+        }
+        $this->setDriver('ibase');
+        try {
+            $db = Database::create(getenv('TINA4_TEST_FIREBIRD_URL'));
+            $adapter = $db->getAdapter();
+            $this->assertInstanceOf(FirebirdAdapter::class, $adapter);
+            $this->assertNotInstanceOf(PdoFirebirdAdapter::class, $adapter);
+            $db->close();
+        } finally {
+            $this->setDriver(null);
+        }
+    }
+
+    /**
+     * The core regression. On Firebird 4 SUM(NUMERIC) is an INT128 result that
+     * crashes ext-interbase; a crash would take the whole test process down
+     * before any assertion runs, so simply completing with the right total
+     * proves pdo_firebird reads the widened aggregate.
+     */
+    public function testSumOverNumericDoesNotCrashOnFirebird4(): void
+    {
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (1, 'a', 100.50)");
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (2, 'b', 200.00)");
+
+        $bare = $this->db->query("SELECT SUM(AMOUNT) AS S FROM {$this->table}");
+        $this->assertEqualsWithDelta(300.50, (float) ($bare[0]['S'] ?? $bare[0]['s'] ?? 0), 0.001);
+
+        // coalesce(sum(...)) also widens to INT128 under FB4.
+        $coalesce = $this->db->query("SELECT COALESCE(SUM(AMOUNT), 0) AS S FROM {$this->table}");
+        $this->assertEqualsWithDelta(300.50, (float) ($coalesce[0]['S'] ?? $coalesce[0]['s'] ?? 0), 0.001);
+
+        $one = $this->db->fetchOne("SELECT SUM(AMOUNT) AS S FROM {$this->table}");
+        $this->assertEqualsWithDelta(300.50, (float) ($one['S'] ?? $one['s'] ?? 0), 0.001);
+    }
+
+    public function testInsertFetchUpdateDelete(): void
+    {
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (1, 'alice', 10)");
+        $row = $this->db->fetchOne("SELECT NAME FROM {$this->table} WHERE ID = ?", [1]);
+        $this->assertSame('alice', $row['NAME'] ?? $row['name']);
+
+        $this->db->execute("UPDATE {$this->table} SET NAME = ? WHERE ID = ?", ['bob', 1]);
+        $row = $this->db->fetchOne("SELECT NAME FROM {$this->table} WHERE ID = ?", [1]);
+        $this->assertSame('bob', $row['NAME'] ?? $row['name']);
+
+        $this->db->execute("DELETE FROM {$this->table} WHERE ID = ?", [1]);
+        $this->assertNull($this->db->fetchOne("SELECT ID FROM {$this->table} WHERE ID = ?", [1]));
+    }
+
+    public function testNullParameterBindsAsSqlNull(): void
+    {
+        // PDO binds a null param as SQL NULL natively — the ibase #123
+        // null-rewrite workaround is not needed on this path.
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (?, ?, ?)", [1, null, 5]);
+        $row = $this->db->fetchOne("SELECT NAME FROM {$this->table} WHERE ID = ?", [1]);
+        $this->assertIsArray($row);
+        $this->assertArrayHasKey('NAME', $row);
+        $this->assertNull($row['NAME']);
+    }
+
+    public function testFetchPaginatesWithRows(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (?, ?, ?)", [$i, "n{$i}", $i]);
+        }
+        $page = $this->db->fetch("SELECT ID FROM {$this->table} ORDER BY ID", [], 2, 0);
+        $this->assertSame(5, $page['total']);
+        $this->assertCount(2, $page['data']);
+    }
+
+    public function testTransactionCommitAndRollback(): void
+    {
+        $this->db->startTransaction();
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (1, 'x', 1)");
+        $this->db->commit();
+        $this->assertNotNull($this->db->fetchOne("SELECT ID FROM {$this->table} WHERE ID = 1"));
+
+        $this->db->startTransaction();
+        $this->db->execute("INSERT INTO {$this->table} (ID, NAME, AMOUNT) VALUES (2, 'y', 2)");
+        $this->db->rollback();
+        $this->assertNull($this->db->fetchOne("SELECT ID FROM {$this->table} WHERE ID = 2"));
+    }
+
+    public function testGetNextIdUsesFirebirdGeneratorOnPdoAdapter(): void
+    {
+        // Through the Database facade so the Firebird generator branch
+        // (guarded by `instanceof FirebirdAdapter`) runs against the PDO adapter.
+        $this->setDriver('pdo');
+        try {
+            $db = Database::create(getenv('TINA4_TEST_FIREBIRD_URL'));
+            $this->assertInstanceOf(PdoFirebirdAdapter::class, $db->getAdapter());
+            $a = $db->getNextId($this->table, 'ID', $this->gen);
+            $b = $db->getNextId($this->table, 'ID', $this->gen);
+            $this->assertSame($a + 1, $b);
+            $db->close();
+        } finally {
+            $this->setDriver(null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Tina4\Database\PdoFirebirdAdapter`, a Firebird transport built on PHP's maintained core **pdo_firebird** driver, and teaches the `Database` factory to prefer it over the deprecated ext-interbase (`ibase_*`) `FirebirdAdapter`.

## Motivation — Firebird 4 crashes ext-interbase

On **Firebird 4+**, the engine widens `SUM()`/`AVG()` over an exact-numeric column to the new 128-bit **`INT128`** type (and `DECFLOAT` for other expressions). The `ibase`/`interbase` extension — removed from PHP core in 7.4, unmaintained, and typically built against the Firebird **3** client API — cannot marshal that result descriptor and **hard-crashes the PHP process** (`SIGSEGV` / `0xC0000005` on Windows). It is a native fault no `try/catch` can trap, so on the built-in server it takes the whole process down mid-request. Every inline aggregate over a numeric column (report totals, footer sums, ledger balances) is affected.

`pdo_firebird` understands the Firebird 4 types and reads `INT128`/`DECFLOAT` back as a string, so the aggregate returns normally. It is the maintained, first-class driver going forward.

## Design

`PdoFirebirdAdapter` **extends** `FirebirdAdapter` deliberately. The framework dispatches Firebird-specific behaviour via `instanceof FirebirdAdapter`:
- the `GEN_ID` generator path in `Database::getNextId()`,
- the Firebird DDL branch in `Migration`,
- `ORM`/`Migration` dialect detection.

Sharing the type identity keeps every one of those sites working unchanged, while the entire I/O surface (connect, `query`, `fetch`, `execute`, transactions, BLOB/CHAR row cleaning) is overridden to run through PDO. The ibase-only workarounds (`#121` fetch_assoc-on-int TypeError, `#123` null-bind XSQLDA fault) are simply not needed on this path — PDO binds a null parameter as SQL NULL natively.

## Driver selection (non-breaking)

`Database::createFirebirdAdapter()` chooses the transport:
- `TINA4_FIREBIRD_DRIVER=pdo` / `ibase` pins the choice,
- unset/auto **prefers pdo_firebird when its extension is loaded**, else falls back to the legacy ibase adapter.

ibase-only environments keep working exactly as before; environments with `pdo_firebird` transparently move onto the modern driver.

## Tests

`tests/PdoFirebirdAdapterTest.php` (live server, **no mocks**, gated on the `pdo_firebird` extension + `TINA4_TEST_FIREBIRD_URL`) covers: connection + Firebird identity, the **FB4 `SUM`/`INT128` regression**, CRUD, null→SQL NULL binding, `ROWS` pagination, commit/rollback, factory auto-select + `ibase` override, and the `getNextId` generator path on the PDO adapter. Validated green against a live **Firebird 4.0.3** database.

## Parity note

`pdo_firebird` is PHP-specific; the equivalent for tina4-python / tina4-ruby / tina4-nodejs is confirming each language's Firebird driver handles the FB4 `INT128`/`DECFLOAT` widening. Flagging that as a follow-up per the cross-framework parity rule — this PR is the PHP piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)