### PR TITLE
skills: add The Tina4 Working Method (operating model)

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -25,6 +25,96 @@ JSON, POST a JSON body and it's automatically parsed into `$request->body`, drop
 > the **global** namespace, so reference framework classes with a leading backslash
 > (`\Tina4\Router`, `\Tina4\Auth`, `\Tina4\QueryBuilder`, `\Tina4\Database\Database`).
 
+## The Tina4 Working Method
+
+This is how a Tina4 build is run. The **main session stays free for the developer**; the actual
+work happens in **workers driven by a plan**. Every instruction becomes (or joins) a plan; every
+plan is a living checklist the workers update and you report from. In the main session your job is
+to **scope, delegate, and report** — never to build inline.
+
+| Phase | What happens | Output |
+|-------|--------------|--------|
+| 1. Scope | Restate the request, agree the slice with the developer | a feature entry in `plan/<feature>.md` |
+| 2. Plan | Write the checklist `[ ]`, Bugs section, Commit log | the plan file, approved |
+| 3. Delegate | Spawn a worker per task; the main session stays free | worker(s) running off the plan |
+| 4. Test-first | The worker writes REAL tests before any code | failing tests that pin the behaviour |
+| 5. Build | Ground with `tina4_context` → climb the reuse ladder → minimum code | tests now green |
+| 6. Verify | Run it for real; tick the item; log the commit | `[x]` + commit hash in the plan |
+| 7. Report | Relay worker completions to the developer as a ✅/❌ table | the status dashboard |
+
+### 1. Keep the main session free — delegate to a worker
+When the developer gives an instruction, don't do the work inline. **Allocate it to a plan, then
+spawn a separate worker to execute it**, so the main session is always free for the next input.
+The main agent scopes, dispatches, and reports; workers build and update the plan. When a worker
+finishes an item, surface it to the developer.
+
+### 2. Every instruction is allocated to a plan
+No work happens off-plan. A new request that fits an existing feature → **rescope it into that
+plan** as new `[ ]` items. A genuinely new feature → **scope it with the developer first**, then
+create `plan/<feature>.md`. Additional features are never side-quests — they are just new
+checkboxes in a plan.
+
+### 3. The feature plan format
+Every feature lives in `plan/<feature>.md` with four parts — a Scope checklist, the Tests, a Bugs
+section, and a Commit log:
+
+```markdown
+# Feature: Product Search API
+
+## Scope
+- [x] Product model (id, name, price, created_at)
+- [x] GET /api/products?q= — search by name
+- [ ] Price-range filter (?min= &max=)
+
+## Tests (written first, real — no mocks)
+- [x] search returns matching products   (real SQLite, seeded rows)
+- [ ] price-range filter narrows results
+
+## Bugs
+- [x] q= containing % broke the LIKE — escaped the wildcards (a1b2c3d)
+- [ ] empty result returns 500 instead of []
+
+## Commits
+- a1b2c3d  product model + search route + real tests
+- e4f5g6h  escape LIKE wildcards in q=
+
+## Status: In Progress
+```
+
+### 4. Tests first — real tests, never smoke tests
+Write the tests **before** the code, and make them real: they hit the actual dependency (a real
+SQLite file, a real HTTP request, a real temp dir), assert real behaviour, and **fail before the
+code exists**. No mocks, stubs, fakes, or "it returned 200" smoke tests — a green mock proves
+nothing (see **No Code Without Tests** and **Testing** below). The passing real test is the
+definition of done for a checklist item.
+
+### 5. Build the minimum, grounded
+Only once the tests exist: ground with `tina4_context`, climb the reuse ladder (most features are
+already in the box), and write the minimum code that makes the tests pass. Nothing speculative.
+
+### 6. Verify for real, then log the commit
+An item is `[x]` only when its real tests pass against a real run. When it lands, record the
+**commit hash + one-line description** in the plan's Commits section, so the plan is an honest
+audit trail of what actually shipped.
+
+### 7. Report as a ✅/❌ dashboard
+Report to the developer as a table, not prose:
+
+| Item                 | Status |
+|----------------------|--------|
+| Product model        | ✅     |
+| Search route         | ✅     |
+| Price-range filter   | ❌     |
+| Bug: 500 on empty    | ❌     |
+
+The developer should see status at a glance without asking. Update the table as workers complete
+items, and surface each completion in the main session.
+
+### Bugs are part of the plan
+Bugs aren't tracked elsewhere — each plan has a **Bugs** section. A bug is logged there as `[ ]`,
+fixed, proven with a **real** test, and ticked `[x]` with its commit hash — the same discipline as
+a feature.
+
 ## Before you write code — the reuse ladder
 
 Climb in order; write new code only at the last rung. Tina4 ships **built-in features, zero dependencies** — most "new code" is already in the box.
@@ -520,6 +610,8 @@ The app includes a health check at `/health` that Kubernetes probes can use.
 
 ## Plan First — Always
 
+> Use the plan **format** from **The Tina4 Working Method** above — Scope / Tests / Bugs / Commits. The workflow below is how you drive it.
+
 Every feature starts with a plan. No exceptions. This isn't overhead — it's how you avoid
 building the wrong thing and how the developer tracks progress.
 
@@ -619,7 +711,7 @@ Local-only commits on shared branches are a risk — push after every milestone.
 
 This is a hard rule. Every piece of functionality gets tests BEFORE it ships:
 
-- **Write the test first or alongside the code** — never after, never "later"
+- **Write the test FIRST — before the code**, never after, never "later". Real tests only — no mocks, no "it returned 200" smoke tests
 - Route handlers get request/response tests
 - ORM models get CRUD tests
 - Business logic in `src/app/` gets unit tests

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -46,6 +46,97 @@ looks simple but has specific rules. Getting them wrong produces silent bugs —
 once but never update, buttons don't disable, inputs don't bind. This reference is the source
 of truth, derived from the actual source code.
 
+## The Tina4 Working Method
+
+This is how a tina4-js build is run. The **main session stays free for the developer**; the actual
+work happens in **workers driven by a plan**. Every instruction becomes (or joins) a plan; every
+plan is a living checklist the workers update and you report from. In the main session your job is
+to **scope, delegate, and report** — never to build inline.
+
+| Phase | What happens | Output |
+|-------|--------------|--------|
+| 1. Scope | Restate the request, agree the slice with the developer | a feature entry in `plan/<feature>.md` |
+| 2. Plan | Write the checklist `[ ]`, Bugs section, Commit log | the plan file, approved |
+| 3. Delegate | Spawn a worker per task; the main session stays free | worker(s) running off the plan |
+| 4. Test-first | The worker pins the behaviour BEFORE building the component | a real check that fails first |
+| 5. Build | Ground with `tina4_context` → climb the Lazy Frontend Ladder → minimum reactive code | it works in the browser |
+| 6. Verify | Run the dev server, drive the real UI; tick the item; log the commit | `[x]` + commit hash in the plan |
+| 7. Report | Relay worker completions to the developer as a ✅/❌ table | the status dashboard |
+
+### 1. Keep the main session free — delegate to a worker
+When the developer gives an instruction, don't do the work inline. **Allocate it to a plan, then
+spawn a separate worker to execute it**, so the main session is always free for the next input.
+The main agent scopes, dispatches, and reports; workers build and update the plan. When a worker
+finishes an item, surface it to the developer.
+
+### 2. Every instruction is allocated to a plan
+No work happens off-plan. A new request that fits an existing feature → **rescope it into that
+plan** as new `[ ]` items. A genuinely new feature → **scope it with the developer first**, then
+create `plan/<feature>.md`. Additional features are never side-quests — they are just new
+checkboxes in a plan.
+
+### 3. The feature plan format
+Every feature lives in `plan/<feature>.md` with four parts — a Scope checklist, the Tests, a Bugs
+section, and a Commit log:
+
+```markdown
+# Feature: Product List Component
+
+## Scope
+- [x] products signal + api load on mount
+- [x] <product-list> renders each product as a card
+- [ ] search box filters the list reactively
+
+## Tests (written first, real — no smoke tests)
+- [x] renders one card per product in the signal   (real DOM, seeded signal)
+- [ ] typing in the search box narrows the rendered cards
+
+## Bugs
+- [x] list didn't re-render on filter — used ${signal.value} not ${signal} (a1b2c3d)
+- [ ] card click navigated before the signal write landed
+
+## Commits
+- a1b2c3d  product-list component + reactive-render test
+- e4f5g6h  fix frozen binding on filter
+
+## Status: In Progress
+```
+
+### 4. Tests first — real behaviour, never smoke tests
+Pin the behaviour before you build the component: assert against the **real rendered DOM** (a real
+signal, a real `` html`` `` render), or run the dev server and drive the real UI — and make it fail
+before the code exists. No mocks, no "it mounted" smoke test: reactivity is the thing under test,
+and a frozen `${signal.value}` where you needed `${signal}` is exactly the bug a real render check
+catches. The passing real check is the definition of done for a checklist item.
+
+### 5. Build the minimum, grounded
+Only once the check exists: ground with `tina4_context`, climb the **Lazy Frontend Ladder** (the
+platform + tina4-js primitives cover most of it — never a React/Vue/state/router library), and
+write the minimum reactive code that passes. Nothing speculative.
+
+### 6. Verify for real, then log the commit
+An item is `[x]` only when the real check passes AND the UI actually behaves in the browser. When
+it lands, record the **commit hash + one-line description** in the plan's Commits section, so the
+plan is an honest audit trail of what actually shipped.
+
+### 7. Report as a ✅/❌ dashboard
+Report to the developer as a table, not prose:
+
+| Item                 | Status |
+|----------------------|--------|
+| products signal      | ✅     |
+| product-list render  | ✅     |
+| reactive search      | ❌     |
+| Bug: nav race        | ❌     |
+
+The developer should see status at a glance without asking. Update the table as workers complete
+items, and surface each completion in the main session.
+
+### Bugs are part of the plan
+Bugs aren't tracked elsewhere — each plan has a **Bugs** section. A bug is logged there as `[ ]`,
+fixed, proven with a **real** render check, and ticked `[x]` with its commit hash — the same
+discipline as a feature.
+
 ## Before you write code — the reuse ladder
 
 Climb in order; write new code only at the last rung. tina4-js is **sub-11 KB, zero dependencies** — reach for its primitives, not a framework.

--- a/.claude/skills/tina4-maintainer/SKILL.md
+++ b/.claude/skills/tina4-maintainer/SKILL.md
@@ -19,6 +19,64 @@ Your job is to write, review, fix, port, and test code that upholds the Tina4 pr
 all four backend implementations moving toward full feature parity. You are not a passive tool —
 you actively look for ways to make Tina4 better: simpler, faster, leaner, greener.
 
+## The Tina4 Working Method
+
+How maintenance work is run. The **main session stays free**; the actual work happens in **workers
+driven by a plan**. You **scope, delegate, and report** — the workers build, update the plan, and
+you relay completions. This section is the map; the detailed sections below own each step
+(**Plan-Driven Workflow**, **Independent Verification & Honest Claims**, **The Parity Mandate**,
+**Communication Style — Dashboard-Driven**).
+
+| Phase | What happens | Output |
+|-------|--------------|--------|
+| 1. Scope | Restate the task; which framework(s) does it land in? | a feature entry in `<repo>/plan/<task>.md` |
+| 2. Plan | Checklist `[ ]` + parity dashboard + Bugs + Commit log | the plan, approved |
+| 3. Delegate | A worker per task/framework; the main session stays free | workers running off the plan |
+| 4. Test-first | REAL tests (positive AND negative) before the code, in every target backend | failing tests that pin the behaviour |
+| 5. Build | Ground with `tina4_context` → reuse ladder → port the proven design → minimum code | tests green, parity held |
+| 6. Verify | **Re-run the full suite yourself at HEAD** (no mocks); tick the item; log the commit | `[x]` + commit hash |
+| 7. Report | A ✅/❌ dashboard per framework | the status table |
+
+### Every instruction is allocated to a plan
+No maintenance happens off-plan. A new request → **rescope it into the plan** as `[ ]` items, or
+scope a new `<repo>/plan/<task>.md`. Additional work is never a side-quest — it is new checkboxes.
+Each plan carries a Scope checklist, a parity dashboard, Tests, a Bugs section, and a Commit log:
+
+```markdown
+# Task: Port Product Search to PHP / Ruby / Node
+
+## Scope
+- [x] Read the Python reference + its tests
+- [ ] PHP adapter + tests
+- [ ] Ruby adapter + tests
+- [ ] Node adapter + tests
+
+## Parity
+| Feature | Python | PHP | Ruby | Node |
+|---------|--------|-----|------|------|
+| search  | ✅     | ❌  | ❌   | ❌   |
+
+## Tests (written first, real — no mocks, positive + negative)
+- [ ] search returns matches   (real SQLite)
+- [ ] blank query returns all, not 500
+
+## Bugs
+- [ ] (log here as [ ], tick when a real test proves it fixed)
+
+## Commits
+- (hash  description — one line per landed change, per framework)
+
+## Status: In Progress
+```
+
+### Tests first, verified independently — never trust a green you didn't run
+Write the tests before the code, in every target backend, real and with negative cases (see
+**Independent Verification & Honest Claims** — the mock-test and `.env.local` lessons). An item is
+`[x]` only after **you** re-ran the full suite at the exact HEAD you are about to ship — an agent's
+own green run has masked real bugs. Log the **commit hash + description** in the plan; report parity
+as a ✅/❌ dashboard (see **Communication Style**). Bugs live in the plan's Bugs section, ticked off
+with their commit when a real test proves them fixed.
+
 ## Before you change the framework — the reuse ladder
 
 Tina4 is **zero-dependency by design**; the whole value proposition is "batteries included, nothing else." Every change should honour that. Climb in order:


### PR DESCRIPTION
## The Tina4 Working Method — codify the operating model

Adds a top-of-skill section stating the working methodology end-to-end (with a worked example) that the existing detailed sections point into — so the method lives in **one** place instead of being scattered/duplicated.

### The method
- **Main session stays free** — work runs in **workers driven by a plan**; the main agent scopes, delegates, reports.
- **Every instruction is allocated to a plan**; a feature is scoped with the developer into `plan/<feature>.md` with a completion checklist `[ ]`.
- **Tests written FIRST** — real tests, no mocks, no smoke tests.
- **Bugs** in a per-plan Bugs section; **commit hashes + descriptions** logged in the plan.
- **Progress reported as a ✅/❌ table**; extra features are rescoped as checkboxes.

### Also
- "Plan First" now points at the new plan format (Scope / Tests / Bugs / Commits).
- "No Code Without Tests" sharpened to tests-before-code.
- Shared `tina4-js` + `tina4-maintainer` synced byte-identical across repos.

Verified: the method was **dry-run end-to-end** — plan file → real test written first (fails) → minimum code → test passes on real SQLite (no mocks) → real commit logged → plan closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)