### PR TITLE
skills: Working Method refinements (hot-reload rationale + master plan)

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -45,8 +45,11 @@ to **scope, delegate, and report** — never to build inline.
 ### 1. Keep the main session free — delegate to a worker
 When the developer gives an instruction, don't do the work inline. **Allocate it to a plan, then
 spawn a separate worker to execute it**, so the main session is always free for the next input.
-The main agent scopes, dispatches, and reports; workers build and update the plan. When a worker
-finishes an item, surface it to the developer.
+Tina4 **hot-reloads on save** (DevReload), so as the worker edits routes, models, and templates the
+developer watches the interface change **live in the browser** — keeping the main session open is
+what lets them observe and steer while the work happens. The main agent scopes, dispatches, and
+reports; workers build and update the plan. When a worker finishes an item, surface it to the
+developer.
 
 ### 2. Every instruction is allocated to a plan
 No work happens off-plan. A new request that fits an existing feature → **rescope it into that
@@ -54,9 +57,21 @@ plan** as new `[ ]` items. A genuinely new feature → **scope it with the devel
 create `plan/<feature>.md`. Additional features are never side-quests — they are just new
 checkboxes in a plan.
 
-### 3. The feature plan format
-Every feature lives in `plan/<feature>.md` with four parts — a Scope checklist, the Tests, a Bugs
-section, and a Commit log:
+### 3. The plan folder — a master plan over feature plans
+`plan/` holds a **master plan** (`plan/MASTER.md`) that carries the overview — every feature and its
+status at a glance — plus one detailed plan per feature. The master plan is the dashboard; each
+feature plan owns the detail:
+
+```markdown
+# Master Plan — <project>
+
+| Feature | Plan | Status |
+|--------------------|-----------------------------------------|----------------|
+| Product search     | [product-search.md](product-search.md)  | ✅ Complete    |
+| Checkout flow      | [checkout.md](checkout.md)              | 🟡 In Progress |
+```
+
+A feature plan has four parts — a Scope checklist, the Tests, a Bugs section, and a Commit log:
 
 ```markdown
 # Feature: Product Search API

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -66,8 +66,11 @@ to **scope, delegate, and report** — never to build inline.
 ### 1. Keep the main session free — delegate to a worker
 When the developer gives an instruction, don't do the work inline. **Allocate it to a plan, then
 spawn a separate worker to execute it**, so the main session is always free for the next input.
-The main agent scopes, dispatches, and reports; workers build and update the plan. When a worker
-finishes an item, surface it to the developer.
+tina4-js **hot-reloads on save** (Vite HMR / the dev server), so as the worker edits components and
+signals the developer watches the UI update **live in the browser** — keeping the main session open
+is what lets them observe and steer while the work happens. The main agent scopes, dispatches, and
+reports; workers build and update the plan. When a worker finishes an item, surface it to the
+developer.
 
 ### 2. Every instruction is allocated to a plan
 No work happens off-plan. A new request that fits an existing feature → **rescope it into that
@@ -75,9 +78,21 @@ plan** as new `[ ]` items. A genuinely new feature → **scope it with the devel
 create `plan/<feature>.md`. Additional features are never side-quests — they are just new
 checkboxes in a plan.
 
-### 3. The feature plan format
-Every feature lives in `plan/<feature>.md` with four parts — a Scope checklist, the Tests, a Bugs
-section, and a Commit log:
+### 3. The plan folder — a master plan over feature plans
+`plan/` holds a **master plan** (`plan/MASTER.md`) that carries the overview — every feature and its
+status at a glance — plus one detailed plan per feature. The master plan is the dashboard; each
+feature plan owns the detail:
+
+```markdown
+# Master Plan — <project>
+
+| Feature | Plan | Status |
+|--------------------|-----------------------------------------|----------------|
+| Product list       | [product-list.md](product-list.md)      | ✅ Complete    |
+| Checkout flow      | [checkout.md](checkout.md)              | 🟡 In Progress |
+```
+
+A feature plan has four parts — a Scope checklist, the Tests, a Bugs section, and a Commit log:
 
 ```markdown
 # Feature: Product List Component

--- a/.claude/skills/tina4-maintainer/SKILL.md
+++ b/.claude/skills/tina4-maintainer/SKILL.md
@@ -38,9 +38,11 @@ you relay completions. This section is the map; the detailed sections below own 
 | 7. Report | A ✅/❌ dashboard per framework | the status table |
 
 ### Every instruction is allocated to a plan
-No maintenance happens off-plan. A new request → **rescope it into the plan** as `[ ]` items, or
-scope a new `<repo>/plan/<task>.md`. Additional work is never a side-quest — it is new checkboxes.
-Each plan carries a Scope checklist, a parity dashboard, Tests, a Bugs section, and a Commit log:
+No maintenance happens off-plan. `<repo>/plan/` holds a **master plan** — the overview of every task
+and its cross-framework status — plus one detailed plan per task. A new request → **rescope it into
+a plan** as `[ ]` items, or scope a new `<repo>/plan/<task>.md`. Additional work is never a
+side-quest — it is new checkboxes. Each plan carries a Scope checklist, a parity dashboard, Tests, a
+Bugs section, and a Commit log:
 
 ```markdown
 # Task: Port Product Search to PHP / Ruby / Node


### PR DESCRIPTION
Two refinements to *The Tina4 Working Method* (follow-up to the initial section):

- **§1 — the hot-reload rationale.** State *why* the main session stays free: Tina4 hot-reloads on save (DevReload), so as the worker edits routes/models/templates the developer watches the interface change **live in the browser** — the main thread stays open so they can observe and steer.
- **§3 — the master plan.** `plan/` holds a **master plan** (the overview/dashboard of every feature + status) over the individual feature plans.

Shared `tina4-js` + `tina4-maintainer` kept byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)