### PR TITLE
skills: skill-active robot marker + branch-drift hint

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -25,6 +25,8 @@ JSON, POST a JSON body and it's automatically parsed into `$request->body`, drop
 > the **global** namespace, so reference framework classes with a leading backslash
 > (`\Tina4\Router`, `\Tina4\Auth`, `\Tina4\QueryBuilder`, `\Tina4\Database\Database`).
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the developer can see at a glance that Tina4 conventions are engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 This is how a Tina4 build is run. The **main session stays free for the developer**; the actual
@@ -724,6 +726,12 @@ so it's tracked and not forgotten. Don't be passive about code quality. Bad patt
 unchecked.
 
 ### Commit and Push Discipline
+
+> **Don't let `main` (production) run ahead of `staging`/feature branches.** Changes flow one way —
+> feature → staging → main. Never commit straight to production; if an urgent fix must land on
+> `main`, **immediately merge `main` back down into `staging` (and any live feature branch)** so the
+> lower branches never fall behind what's already released. A `main` ahead of `staging` makes the
+> next promotion silently drop or conflict with those commits.
 
 **After completing any feature or milestone:** run tests (all must pass), commit with a clear
 message describing what was built, and if on `development` or `staging`, **push immediately**.

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -46,6 +46,8 @@ looks simple but has specific rules. Getting them wrong produces silent bugs —
 once but never update, buttons don't disable, inputs don't bind. This reference is the source
 of truth, derived from the actual source code.
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the developer can see at a glance that Tina4 conventions are engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 This is how a tina4-js build is run. The **main session stays free for the developer**; the actual

--- a/.claude/skills/tina4-maintainer/SKILL.md
+++ b/.claude/skills/tina4-maintainer/SKILL.md
@@ -19,6 +19,8 @@ Your job is to write, review, fix, port, and test code that upholds the Tina4 pr
 all four backend implementations moving toward full feature parity. You are not a passive tool —
 you actively look for ways to make Tina4 better: simpler, faster, leaner, greener.
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the maintainer can see at a glance that the Tina4 skill is engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 How maintenance work is run. The **main session stays free**; the actual work happens in **workers
@@ -734,6 +736,12 @@ The branching model follows: **development → staging → main**
 feature/* → development → staging (v3 beta) → main (production)
 hotfix/*  → main + development
 ```
+
+**Never let `main` run ahead of `staging`.** A hotfix on `main` is only half-done until it's merged
+back to `development`/`staging` — that is exactly the `hotfix/* → main + development` rule above. If
+`main` carries commits `staging` doesn't, the next `staging → main` promotion silently drops or
+conflicts with them, so **back-merge production down immediately** and keep the lower branches from
+falling behind what users already run.
 
 When working on Tina4:
 - **Ask which branch** — Is this a v2 hotfix or v3 feature work? Don't assume.


### PR DESCRIPTION
Two skill additions, propagated:
- **Skill-active marker**: begin replies with 🤖 while a Tina4 skill is guiding the work, so the developer can *see* it's engaged.
- **Branch-drift hint**: don't let `main` run ahead of `staging`/feature branches — changes flow feature → staging → main; back-merge `main` down immediately after a hotfix.

Shared tina4-js + tina4-maintainer kept byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)