### PR TITLE
release: bump version 3.13.59

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.58 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.59 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 


### PR DESCRIPTION
Bump 3.13.58 → **3.13.59** for the release. This tag ships the accumulated `v3` work: the skills overhaul (Working Method, WebRTC docs, ladders, tina4 metrics/update, branch-drift hint, robot marker) and the **SQLite absolute-path parity fix** across all four backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)