### PR TITLE
release: 3.13.60 -> 3.13.61

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.60 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.61 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 


### PR DESCRIPTION
Version bump for 3.13.61 (ORM footguns + batteries + save() hint parity across all 4). Tag follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)