### PR TITLE
context: native Context code/doc grounding subsystem (parity with python)

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -169,13 +169,16 @@ running (`tina4php serve` with `TINA4_DEBUG=true`):
 - **`api_search("render template")`** — ranked search across the framework + your own code; returns fqn, signature, file:line. Run it BEFORE assuming a method exists.
 - **`api_class("Frond")`** — every method on a class, with signatures. A bare name (`Frond`) or the full fqn (`Tina4\Frond`) both resolve.
 - **`api_method("Frond", "addTest")`** — exact signature, params, return type, file and line for one method.
+- **`code_search("where is the auth token issued?")`** — fuzzy/semantic full-text search over **THIS project's own source + docs** (the native `Context` FTS5 index — zero-dep, kept live on every file save). Ranks the file that *defines* a symbol above tests that merely mention it. The in-repo, semantic counterpart to `api_*`.
 
 ```
 api_search("queue consume")     -> finds Queue::consume and its signature
 api_class("Database")           -> every method on Database, with signatures
 api_method("Auth", "getToken")  -> getToken(array $payload, string|int|null $secret = null, int $expiresIn = 60): string
+code_search("send an email")    -> the routes/services in YOUR app that already do it
 ```
 
+- **The grounding ladder — pick the tool by the question.** `api_*` = *exact structure* ("what's the signature of X?"); `code_search` = *semantic, in your own repo* ("where/how is X done in THIS app?"); `docs_search` = the prose docs; `tina4_context` = the current framework API + idioms (external corpus, for framework facts not in your project).
 - **PHP method names are camelCase** (`fromTable`, `findById`, `getToken`, `checkPassword`, `addTest`).
 - **Unsure of a name or signature? Look it up — don't recall it.** A 5-second `api_method` call beats a hallucinated method that costs 20 minutes of debugging.
 - **`api_*` is live reflection (exact code); `docs_search` searches the prose docs.** Use `api_*` for signatures, `docs_search` for "how do I X" guidance.

--- a/Tina4/Context.php
+++ b/Tina4/Context.php
@@ -9,9 +9,10 @@
  *
  * Lets a Tina4 app ground its own AI assistant on its own source, offline:
  * it walks the project, chunks code on def/class/function boundaries and docs
- * as prose, and answers keyword/fuzzy queries over a SQLite FTS5 index
- * (PDO ``pdo_sqlite`` — FTS5 + ``bm25()`` are built into modern SQLite, so NO
- * new composer dependency).
+ * as prose, and answers keyword/fuzzy queries over a SQLite FTS5 index using
+ * the ``sqlite3`` extension — the SAME binding tina4's SQLite3Adapter uses, so
+ * NO new dependency and no second SQLite extension beyond what the framework
+ * already requires (FTS5 + ``bm25()`` are built into modern SQLite).
  *
  * A faithful PHP port of tina4-python's tina4_python/context (the proven slice
  * of neemee's longmem-harness retrieval). It COMPLEMENTS the ``api_*``
@@ -72,7 +73,7 @@ class Context
     public bool $available = false;
     /** Set by indexRoot; reindexFile relabels a changed file against it. */
     private ?string $root = null;
-    private ?\PDO $conn = null;
+    private ?\SQLite3 $conn = null;
 
     /**
      * @param string        $path      on-disk index file (its parent dir is created)
@@ -91,8 +92,8 @@ class Context
         if ($parent !== '' && $parent !== '.' && !is_dir($parent)) {
             @mkdir($parent, 0755, true);
         }
-        $this->conn = new \PDO('sqlite:' . $path);
-        $this->conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->conn = new \SQLite3($path);
+        $this->conn->enableExceptions(true);
         // tina4: no per-connection lock. PHP's request model is synchronous and
         // share-nothing (unlike the Python master, where a dev-MCP worker thread
         // shares one connection and needs a threading.Lock). Add one only if a
@@ -102,18 +103,24 @@ class Context
 
     // ── FTS5 availability ───────────────────────────────────────
 
-    /** Whether this PHP's PDO SQLite supports FTS5 (real probe). */
+    /** Whether this PHP's sqlite3 extension supports FTS5 (real probe). */
     public static function fts5Available(): bool
     {
         return self::probeFts5();
     }
 
-    /** True if an in-memory SQLite can create an FTS5 virtual table. */
+    /**
+     * True if an in-memory SQLite can create an FTS5 virtual table. Also returns
+     * false (not fatal) when the sqlite3 extension itself is absent — `new
+     * SQLite3` throws an Error we catch, so the Context degrades to safe no-ops.
+     */
     public static function probeFts5(): bool
     {
         try {
-            $db = new \PDO('sqlite::memory:');
+            $db = new \SQLite3(':memory:');
+            $db->enableExceptions(true);
             $db->exec('CREATE VIRTUAL TABLE _probe USING fts5(x)');
+            $db->close();
             return true;
         } catch (\Throwable $e) {
             return false;
@@ -184,20 +191,27 @@ class Context
         foreach ($this->chunksFor($stored, $text) as [$i, $chunk]) {
             $rows[] = ["{$stored}:{$i}", $stored, $chunk, ContextChunker::fold($chunk)];
         }
-        $this->conn->beginTransaction();
+        $this->conn->exec('BEGIN');
         try {
-            $this->conn->prepare('DELETE FROM chunks WHERE path = ?')->execute([$stored]);
+            $del = $this->conn->prepare('DELETE FROM chunks WHERE path = ?');
+            $del->bindValue(1, $stored, SQLITE3_TEXT);   // TEXT (never BLOB) so the DELETE matches
+            $del->execute();
             if (!empty($rows)) {
                 $insert = $this->conn->prepare(
                     'INSERT INTO chunks(cid, path, raw, body) VALUES (?, ?, ?, ?)'
                 );
                 foreach ($rows as $row) {
-                    $insert->execute($row);
+                    $insert->bindValue(1, $row[0], SQLITE3_TEXT);
+                    $insert->bindValue(2, $row[1], SQLITE3_TEXT);
+                    $insert->bindValue(3, $row[2], SQLITE3_TEXT);
+                    $insert->bindValue(4, $row[3], SQLITE3_TEXT);
+                    $insert->execute();
+                    $insert->reset();
                 }
             }
-            $this->conn->commit();
+            $this->conn->exec('COMMIT');
         } catch (\Throwable $e) {
-            $this->conn->rollBack();
+            $this->conn->exec('ROLLBACK');
             throw $e;
         }
         return count($rows);
@@ -328,7 +342,9 @@ class Context
             return -1;
         }
         if (!file_exists($abs)) {                     // deleted → drop its chunks
-            $this->conn->prepare('DELETE FROM chunks WHERE path = ?')->execute([$rel]);
+            $del = $this->conn->prepare('DELETE FROM chunks WHERE path = ?');
+            $del->bindValue(1, $rel, SQLITE3_TEXT);
+            $del->execute();
             return 0;
         }
         return $this->indexPath($abs, $rel);
@@ -411,10 +427,13 @@ class Context
             'SELECT path, raw, body, bm25(chunks) AS s FROM chunks '
             . 'WHERE chunks MATCH ? ORDER BY s LIMIT ?'
         );
-        $stmt->bindValue(1, $expr, \PDO::PARAM_STR);
-        $stmt->bindValue(2, $poolN, \PDO::PARAM_INT);
-        $stmt->execute();
-        $rows = $stmt->fetchAll(\PDO::FETCH_NUM);
+        $stmt->bindValue(1, $expr, SQLITE3_TEXT);
+        $stmt->bindValue(2, $poolN, SQLITE3_INTEGER);
+        $result = $stmt->execute();
+        $rows = [];
+        while (($row = $result->fetchArray(SQLITE3_NUM)) !== false) {
+            $rows[] = $row;
+        }
         if (empty($rows)) {
             return [];
         }
@@ -467,7 +486,7 @@ class Context
         if (!$this->available) {
             return 0;
         }
-        return (int) $this->conn->query('SELECT count(*) FROM chunks')->fetchColumn();
+        return (int) $this->conn->querySingle('SELECT count(*) FROM chunks');
     }
 
     public function isEmpty(): bool
@@ -477,7 +496,10 @@ class Context
 
     public function close(): void
     {
-        $this->conn = null;
+        if ($this->conn !== null) {
+            $this->conn->close();
+            $this->conn = null;
+        }
     }
 
     // ── helpers ─────────────────────────────────────────────────

--- a/Tina4/Context.php
+++ b/Tina4/Context.php
@@ -1,0 +1,585 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Context — a native, zero-dependency code/doc grounding index.
+ *
+ * Lets a Tina4 app ground its own AI assistant on its own source, offline:
+ * it walks the project, chunks code on def/class/function boundaries and docs
+ * as prose, and answers keyword/fuzzy queries over a SQLite FTS5 index
+ * (PDO ``pdo_sqlite`` — FTS5 + ``bm25()`` are built into modern SQLite, so NO
+ * new composer dependency).
+ *
+ * A faithful PHP port of tina4-python's tina4_python/context (the proven slice
+ * of neemee's longmem-harness retrieval). It COMPLEMENTS the ``api_*``
+ * reflection tools (Docs): ``api_*`` is exact structural lookup, Context is
+ * fuzzy/semantic FTS over source + docs.
+ *
+ *     use Tina4\Context;
+ *     $ctx = new Context(".tina4/context.db");
+ *     $ctx->indexRoot("src");
+ *     $ctx->search("where is the auth token issued?", 5);
+ *     //  -> [["path" => "src/Auth.php", "score" => 2.31, "snippet" => "..."], ...]
+ *
+ * On-disk index defaults to ``.tina4/context.db`` (gitignored). Guards a
+ * SQLite build without FTS5: if absent, the Context degrades to safe no-ops
+ * rather than crashing the app — exactly like the Python master.
+ */
+
+namespace Tina4;
+
+class Context
+{
+    // File classification — mirrors neemee's repo walk (extensions carry the dot).
+    private const CODE_EXTS = [
+        '.py', '.php', '.js', '.mjs', '.ts', '.rb',
+        '.pas', '.dpr', '.dpk', '.inc', '.dfm', '.fmx',
+    ];
+    private const DOC_EXTS = ['.md', '.txt', '.rst', '.twig', '.html'];
+    // deploy/CLI/env answers live in config files, not sources — chunk as code
+    // (line windows), since sentence chunking shreds YAML/Dockerfiles.
+    private const CONFIG_EXTS = ['.toml', '.yml', '.yaml'];
+    private const SPECIAL_FILES = [
+        'dockerfile', 'makefile', 'docker-compose.yml',
+        'package.json', 'composer.json',
+        '.env.example', '.env.sample',
+    ];
+    // Same dirs neemee skips, plus Tina4 runtime dirs that hold no source of
+    // truth (our own index/backups, session blobs, logs).
+    private const SKIP_DIRS = [
+        '.git', '__pycache__', 'node_modules', 'vendor', 'dist',
+        'build', 'coverage', '.idea', '.venv', 'venv', '.pytest_cache',
+        '.tina4', 'sessions', 'logs',
+    ];
+
+    // generic question/code vocabulary that never NAMES a symbol — kept small.
+    private const DEF_STOP = [
+        'the', 'and', 'what', 'how', 'does', 'can', 'which', 'where', 'when',
+        'who', 'why', 'list', 'all', 'available', 'module', 'class', 'function',
+        'functions', 'method', 'methods', 'def', 'get', 'set', 'new', 'return',
+        'import', 'from', 'with', 'that', 'this', 'are', 'is', 'was', 'for',
+        'into', 'use', 'used',
+    ];
+
+    // a chunk that DEFINES a queried symbol ('function getToken', 'class Widget')
+    // should out-rank one that merely USES it. Matched against the folded body.
+    private const DEF_KW = '(?:async def|def|class|function|fn|func|interface|trait)';
+
+    public string $path;
+    public bool $available = false;
+    /** Set by indexRoot; reindexFile relabels a changed file against it. */
+    private ?string $root = null;
+    private ?\PDO $conn = null;
+
+    /**
+     * @param string        $path      on-disk index file (its parent dir is created)
+     * @param callable|null $fts5Check overrides FTS5 detection (tests exercise the
+     *                                 graceful-degradation path); defaults to a real probe.
+     */
+    public function __construct(string $path = './.tina4/context.db', ?callable $fts5Check = null)
+    {
+        $this->path = $path;
+        $check = $fts5Check ?? [self::class, 'probeFts5'];
+        $this->available = (bool) $check();
+        if (!$this->available) {
+            return;
+        }
+        $parent = dirname($path);
+        if ($parent !== '' && $parent !== '.' && !is_dir($parent)) {
+            @mkdir($parent, 0755, true);
+        }
+        $this->conn = new \PDO('sqlite:' . $path);
+        $this->conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        // tina4: no per-connection lock. PHP's request model is synchronous and
+        // share-nothing (unlike the Python master, where a dev-MCP worker thread
+        // shares one connection and needs a threading.Lock). Add one only if a
+        // future async SAPI shares a Context across concurrent handlers.
+        $this->ensureTable();
+    }
+
+    // ── FTS5 availability ───────────────────────────────────────
+
+    /** Whether this PHP's PDO SQLite supports FTS5 (real probe). */
+    public static function fts5Available(): bool
+    {
+        return self::probeFts5();
+    }
+
+    /** True if an in-memory SQLite can create an FTS5 virtual table. */
+    public static function probeFts5(): bool
+    {
+        try {
+            $db = new \PDO('sqlite::memory:');
+            $db->exec('CREATE VIRTUAL TABLE _probe USING fts5(x)');
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    // ── schema ──────────────────────────────────────────────────
+
+    private function ensureTable(): void
+    {
+        // `body` holds fold(text) so query/index tokenization is symmetric;
+        // `raw` (UNINDEXED) keeps the original text to return as a snippet;
+        // `path`/`cid` (UNINDEXED) are metadata used for upsert + citation.
+        $this->conn->exec(
+            'CREATE VIRTUAL TABLE IF NOT EXISTS chunks '
+            . 'USING fts5(cid UNINDEXED, path UNINDEXED, raw UNINDEXED, body)'
+        );
+    }
+
+    /** Drop and recreate the index (full rebuild starting point). */
+    public function reset(): void
+    {
+        if (!$this->available) {
+            return;
+        }
+        $this->conn->exec('DROP TABLE IF EXISTS chunks');
+        $this->ensureTable();
+    }
+
+    // ── indexing ────────────────────────────────────────────────
+
+    /**
+     * (index, chunkText) pairs — code/config files on def/class/function
+     * boundaries, everything else (docs) as prose.
+     *
+     * @return array<int, array{0:int, 1:string}>
+     */
+    private function chunksFor(string $label, string $text): array
+    {
+        $ext = self::extensionOf($label);
+        $special = in_array(strtolower(basename($label)), self::SPECIAL_FILES, true);
+        if (in_array($ext, self::CODE_EXTS, true)
+            || in_array($ext, self::CONFIG_EXTS, true)
+            || $special) {
+            return ContextChunker::chunkCode($text, $label);
+        }
+        return ContextChunker::chunkText($text);
+    }
+
+    /**
+     * UPSERT one file into the index: delete this path's existing chunks,
+     * re-chunk the current contents, insert. A single file save re-indexes
+     * just that file. `$label` is the stored/citation path (defaults to
+     * `$file`) and MUST be stable across calls for the same file so the delete
+     * targets the right rows. Returns rows inserted.
+     */
+    public function indexPath(string $file, ?string $label = null): int
+    {
+        if (!$this->available) {
+            return 0;
+        }
+        $stored = $label !== null ? $label : $file;
+        $text = @file_get_contents($file);
+        if ($text === false) {
+            return 0;
+        }
+        $rows = [];
+        foreach ($this->chunksFor($stored, $text) as [$i, $chunk]) {
+            $rows[] = ["{$stored}:{$i}", $stored, $chunk, ContextChunker::fold($chunk)];
+        }
+        $this->conn->beginTransaction();
+        try {
+            $this->conn->prepare('DELETE FROM chunks WHERE path = ?')->execute([$stored]);
+            if (!empty($rows)) {
+                $insert = $this->conn->prepare(
+                    'INSERT INTO chunks(cid, path, raw, body) VALUES (?, ?, ?, ?)'
+                );
+                foreach ($rows as $row) {
+                    $insert->execute($row);
+                }
+            }
+            $this->conn->commit();
+        } catch (\Throwable $e) {
+            $this->conn->rollBack();
+            throw $e;
+        }
+        return count($rows);
+    }
+
+    /**
+     * True if a file should be indexed (the per-file filter used by both
+     * indexRoot and reindexFile). Directory skipping is handled separately.
+     */
+    private static function eligible(string $filename): bool
+    {
+        $fn = strtolower($filename);
+        if (str_ends_with($fn, '.min.js')) {
+            return false;
+        }
+        $ext = self::extensionOf($fn);
+        return in_array($ext, self::CODE_EXTS, true)
+            || in_array($ext, self::DOC_EXTS, true)
+            || in_array($ext, self::CONFIG_EXTS, true)
+            || in_array($fn, self::SPECIAL_FILES, true);
+    }
+
+    /**
+     * Walk `$root`, indexing every eligible file (skips vendor/build/runtime
+     * dirs). Paths are stored RELATIVE to `$root` for clean citations. Records
+     * `$root` so reindexFile can relabel a changed file consistently. Returns
+     * the total number of chunks inserted.
+     */
+    public function indexRoot(string $root): int
+    {
+        if (!$this->available) {
+            return 0;
+        }
+        $resolved = realpath($root);
+        if ($resolved === false) {
+            return 0;
+        }
+        $this->root = $resolved;
+        return $this->walk($resolved, $resolved);
+    }
+
+    /** Recursive tree walk with skip-dir + dot-dir pruning. */
+    private function walk(string $dir, string $root): int
+    {
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            return 0;
+        }
+        sort($entries);
+        $dirs = [];
+        $files = [];
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $full = $dir . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($full)) {
+                if (in_array($entry, self::SKIP_DIRS, true) || str_starts_with($entry, '.')) {
+                    continue;
+                }
+                $dirs[] = $entry;
+            } else {
+                $files[] = $entry;
+            }
+        }
+        $total = 0;
+        foreach ($files as $fn) {
+            if (!self::eligible($fn)) {
+                continue;
+            }
+            $full = $dir . DIRECTORY_SEPARATOR . $fn;
+            $rel = str_replace(DIRECTORY_SEPARATOR, '/', ltrim(substr($full, strlen($root)), DIRECTORY_SEPARATOR));
+            $total += $this->indexPath($full, $rel);
+        }
+        foreach ($dirs as $d) {
+            $total += $this->walk($dir . DIRECTORY_SEPARATOR . $d, $root);
+        }
+        return $total;
+    }
+
+    /**
+     * Re-index a single changed file into the LIVE index — the hook the dev
+     * reload trigger (POST /__dev/api/reload) calls so code_search tracks edits
+     * without a rebuild. Resolves `$changedPath` against the indexed root, then:
+     * outside root / under a skip-or-dot dir / ineligible → skip (-1);
+     * deleted → drop its chunks (0); otherwise UPSERT (rows). No-op (-1) until
+     * indexRoot has run (nothing to keep fresh yet).
+     */
+    public function reindexFile(string $changedPath): int
+    {
+        if (!$this->available || $this->root === null) {
+            return -1;
+        }
+        // The reload trigger reports paths relative to the project root (cwd
+        // during `tina4 serve`); the index root may be a subdir like src/.
+        $path = $changedPath;
+        if (!self::isAbsolutePath($path)) {
+            $cwd = getcwd();
+            $path = ($cwd !== false ? $cwd : '.') . DIRECTORY_SEPARATOR . $changedPath;
+        }
+        // Resolve symlinks on the parent dir (handles /tmp -> /private/tmp on
+        // macOS) even when the file itself was deleted — the parent still
+        // exists. realpath() of the whole path would return false for a
+        // deleted file, so we can't use it directly.
+        $realDir = realpath(dirname($path));
+        if ($realDir === false) {
+            return -1;                               // parent gone → outside/invalid
+        }
+        $abs = $realDir . DIRECTORY_SEPARATOR . basename($path);
+
+        $rootPrefix = rtrim($this->root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (!str_starts_with($abs . DIRECTORY_SEPARATOR, $rootPrefix)) {
+            return -1;                               // outside the indexed root
+        }
+        $rel = str_replace(DIRECTORY_SEPARATOR, '/', substr($abs, strlen($rootPrefix)));
+        $parts = explode('/', $rel);
+        foreach ($parts as $part) {
+            if (in_array($part, self::SKIP_DIRS, true)) {
+                return -1;                           // under a skipped dir
+            }
+        }
+        foreach (array_slice($parts, 0, -1) as $dirPart) {
+            if (str_starts_with($dirPart, '.')) {
+                return -1;                           // under a dot dir
+            }
+        }
+        if (!self::eligible(basename($rel))) {
+            return -1;
+        }
+        if (!file_exists($abs)) {                     // deleted → drop its chunks
+            $this->conn->prepare('DELETE FROM chunks WHERE path = ?')->execute([$rel]);
+            return 0;
+        }
+        return $this->indexPath($abs, $rel);
+    }
+
+    // ── query ───────────────────────────────────────────────────
+
+    /**
+     * Build the FTS5 MATCH string: each folded query token (plus its light
+     * stem) as a quoted OR term. Quoting keeps it injection-safe (tokens are
+     * `[a-z0-9]+`, so no quote can appear inside one). Returns null when the
+     * query has no usable tokens.
+     */
+    private function matchExpr(string $query): ?string
+    {
+        $toks = [];
+        foreach (ContextChunker::terms($query) as $t) {
+            $toks[$t] = true;
+            $toks[ContextChunker::lightStem($t)] = true;
+        }
+        unset($toks['']);
+        if (empty($toks)) {
+            return null;
+        }
+        $keys = array_keys($toks);
+        sort($keys);
+        $quoted = array_map(static fn ($t) => '"' . $t . '"', $keys);
+        return implode(' OR ', $quoted);
+    }
+
+    private static function isTestlike(?string $path): bool
+    {
+        $s = strtolower($path ?? '');
+        foreach (['/test', 'test/', 'test_', '_test.', '.test.', '/example', 'example/'] as $needle) {
+            if (str_contains($s, $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True if the folded body DEFINES any of `$symbols` (a def keyword directly
+     * followed by the symbol, not merely a use of it).
+     *
+     * @param string[] $symbols
+     */
+    private function defines(string $foldedBody, array $symbols): bool
+    {
+        if (empty($symbols)) {
+            return false;
+        }
+        $escaped = array_map(static fn ($s) => preg_quote($s, '/'), $symbols);
+        $pattern = '/' . self::DEF_KW . '\s+(?:' . implode('|', $escaped) . ')(?![a-z0-9])/';
+        return preg_match($pattern, $foldedBody) === 1;
+    }
+
+    /**
+     * Return the top-`$k` chunks as `[["path"=>, "score"=>, "snippet"=>], ...]`,
+     * ranked by `bm25()` then reordered with two stable, proven passes:
+     *   - source-over-tests: a test that merely mentions a symbol sinks below
+     *     the source that defines it (skipped when the query is about tests);
+     *   - definition-first: a chunk that DEFINES a queried symbol rises above
+     *     chunks that only use it.
+     * Score is a higher-is-better float (SQLite's bm25 sign flipped).
+     *
+     * @return array<int, array{path:string, score:float, snippet:string}>
+     */
+    public function search(string $query, int $k = 5): array
+    {
+        if (!$this->available) {
+            return [];
+        }
+        $expr = $this->matchExpr($query);
+        if ($expr === null) {
+            return [];
+        }
+        $poolN = max($k * 3, 15);
+        $stmt = $this->conn->prepare(
+            'SELECT path, raw, body, bm25(chunks) AS s FROM chunks '
+            . 'WHERE chunks MATCH ? ORDER BY s LIMIT ?'
+        );
+        $stmt->bindValue(1, $expr, \PDO::PARAM_STR);
+        $stmt->bindValue(2, $poolN, \PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(\PDO::FETCH_NUM);
+        if (empty($rows)) {
+            return [];
+        }
+
+        // candidate symbol names from the query (drop generic vocab).
+        $symbols = [];
+        foreach (ContextChunker::terms($query) as $t) {
+            if (strlen($t) >= 3 && !in_array($t, self::DEF_STOP, true)) {
+                $symbols[$t] = true;
+            }
+        }
+        $symbols = array_keys($symbols);
+        $aboutTests = str_contains(strtolower($query), 'test');
+
+        // Reorder by (is_test, is_def, bm25_index) — bm25 order breaks ties.
+        $ranked = [];
+        foreach ($rows as $idx => $row) {
+            [$path, $raw, $body, $s] = $row;
+            $isTest = (!$aboutTests && self::isTestlike($path)) ? 1 : 0;
+            $isDef = $this->defines($body, $symbols) ? 0 : 1;
+            $ranked[] = ['key' => [$isTest, $isDef, $idx], 'row' => $row];
+        }
+        usort($ranked, static fn ($a, $b) => $a['key'] <=> $b['key']);
+
+        $out = [];
+        foreach (array_slice($ranked, 0, $k) as $item) {
+            [$path, $raw, $body, $s] = $item['row'];
+            $out[] = [
+                'path' => $path,
+                'score' => round(-(float) $s, 6),    // bm25: more negative = better
+                'snippet' => self::snippet($raw),
+            ];
+        }
+        return $out;
+    }
+
+    private static function snippet(?string $raw, int $limit = 280): string
+    {
+        $text = trim($raw ?? '');
+        if (strlen($text) <= $limit) {
+            return $text;
+        }
+        return rtrim(substr($text, 0, $limit)) . ' ...';
+    }
+
+    // ── misc ────────────────────────────────────────────────────
+
+    public function count(): int
+    {
+        if (!$this->available) {
+            return 0;
+        }
+        return (int) $this->conn->query('SELECT count(*) FROM chunks')->fetchColumn();
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
+
+    public function close(): void
+    {
+        $this->conn = null;
+    }
+
+    // ── helpers ─────────────────────────────────────────────────
+
+    /** Extension INCLUDING the leading dot ('.php'), or '' when there is none. */
+    private static function extensionOf(string $name): string
+    {
+        $base = basename($name);
+        $dot = strrpos($base, '.');
+        // A leading-dot-only name ('.env') has no extension in the os.path sense.
+        if ($dot === false || $dot === 0) {
+            return '';
+        }
+        return substr($base, $dot);
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        return $path !== ''
+            && ($path[0] === '/' || preg_match('#^[A-Za-z]:[\\\\/]#', $path) === 1);
+    }
+
+    // ── process-wide shared index ───────────────────────────────
+    // code_search (dev MCP) and the dev-reload reindex hook must share ONE
+    // index so a saved file is immediately searchable. Keyed by canonical db
+    // path. Mirrors the Python master's default_context / existing_context.
+
+    /** @var array<string, Context> */
+    private static array $sharedContexts = [];
+
+    /**
+     * Get (or create) the process-wide Context at `$db` (default
+     * `<cwd>/.tina4/context.db`). If `$root` is given and the index is empty,
+     * builds it once. This is what code_search uses so the reload hook can keep
+     * the SAME index fresh.
+     */
+    public static function defaultContext(?string $root = null, ?string $db = null): self
+    {
+        $target = $db ?? self::defaultDbPath();
+        $key = self::dbKey($target);
+        if (!isset(self::$sharedContexts[$key])) {
+            self::$sharedContexts[$key] = new self($target);
+        }
+        $ctx = self::$sharedContexts[$key];
+        if ($root !== null && $ctx->available && $ctx->isEmpty()) {
+            $ctx->indexRoot($root);
+        }
+        return $ctx;
+    }
+
+    /**
+     * Return the already-created shared Context for `$db` (or null). Used by the
+     * reload hook so a file change reindexes an EXISTING index but never creates
+     * one on its own (nothing to keep fresh until code_search runs).
+     */
+    public static function existingContext(?string $db = null): ?self
+    {
+        return self::$sharedContexts[self::dbKey($db ?? self::defaultDbPath())] ?? null;
+    }
+
+    /** Drop the shared registry (test helper). */
+    public static function clearShared(): void
+    {
+        self::$sharedContexts = [];
+    }
+
+    private static function defaultDbPath(): string
+    {
+        $cwd = getcwd();
+        return ($cwd !== false ? $cwd : '.') . DIRECTORY_SEPARATOR . '.tina4' . DIRECTORY_SEPARATOR . 'context.db';
+    }
+
+    /**
+     * Canonical, symlink-resolved key for a db path — stable whether or not the
+     * file exists yet (resolves the longest existing ancestor, keeps the
+     * non-existent tail). Mirrors Python's Path.resolve() on a not-yet-created
+     * path, so defaultContext() and a later existingContext() agree on the key.
+     */
+    private static function dbKey(string $path): string
+    {
+        if ($path !== '' && !self::isAbsolutePath($path)) {
+            $cwd = getcwd();
+            $path = ($cwd !== false ? $cwd : '.') . DIRECTORY_SEPARATOR . $path;
+        }
+        $real = realpath($path);
+        if ($real !== false) {
+            return $real;
+        }
+        $sep = DIRECTORY_SEPARATOR;
+        $parts = preg_split('#[\\\\/]+#', $path) ?: [];
+        $tail = [];
+        for ($i = count($parts); $i > 0; $i--) {
+            $prefix = implode($sep, array_slice($parts, 0, $i));
+            if ($prefix === '') {
+                $prefix = $sep;
+            }
+            $realPrefix = realpath($prefix);
+            if ($realPrefix !== false) {
+                return rtrim($realPrefix, $sep) . (empty($tail) ? '' : $sep . implode($sep, $tail));
+            }
+            array_unshift($tail, $parts[$i - 1]);
+        }
+        return $path;
+    }
+}

--- a/Tina4/ContextChunker.php
+++ b/Tina4/ContextChunker.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Text folding + chunking for the Context subsystem.
+ *
+ * A faithful PHP port of the proven slice of tina4-python's
+ * tina4_python/context/chunker.py (itself a port of neemee's
+ * longmem-harness tokenizer/chunkers). Pure stdlib — PCRE + a little
+ * mbstring/intl. Nothing here touches SQLite; it produces the
+ * (folded body, raw text) pairs the FTS5 index stores.
+ */
+
+namespace Tina4;
+
+class ContextChunker
+{
+    // Chunk boundaries across languages: python defs/classes/decorators, php/js
+    // functions and methods, ts exports/interfaces, php traits, and Object Pascal
+    // unit/type/routine headers (Delphi is case-insensitive, accept either case).
+    // Matched per-line, anchored at the start of the line.
+    private const TOPLEVEL =
+        '/^(async def |def |class |@\w'
+        . '|\s*(?:public |private |protected |static |final |abstract )*function \w'
+        . '|(?:export )?(?:default )?(?:abstract )?class '
+        . '|interface |trait '
+        . '|export (?:const|function|interface|type|async) '
+        . '|[Uu]nit |[Pp]rocedure |[Ff]unction |[Cc]onstructor |[Dd]estructor '
+        . '|[Tt]ype$)/';
+
+    /**
+     * Lowercase, strip diacritics, join comma-grouped numbers, split camelCase.
+     *
+     * Applied symmetrically to the indexed `body` and to query tokens so
+     * matching is consistent: a query for `field` reaches `IntegerField`.
+     */
+    public static function fold(string $text): string
+    {
+        // join comma-grouped numbers ("24,601" -> "24601")
+        $text = (string) preg_replace('/(?<=\d),(?=\d)/', '', $text);
+        // split camelCase ("ForeignKeyField" -> "foreign key field") BEFORE lower
+        $text = (string) preg_replace('/(?<=[a-z0-9])(?=[A-Z])/', ' ', $text);
+        $text = function_exists('mb_strtolower') ? mb_strtolower($text, 'UTF-8') : strtolower($text);
+        // NFKD decomposition then drop non-ascii — mirrors Python's
+        // unicodedata.normalize("NFKD", t).encode("ascii", "ignore"): é -> e.
+        // tina4: falls back to a plain non-ascii strip when ext-intl is absent
+        // (accented chars lose their base letter — rare, and symmetric on both
+        // sides so matching stays internally consistent).
+        if (class_exists('\Normalizer')) {
+            $normalized = \Normalizer::normalize($text, \Normalizer::FORM_KD);
+            if ($normalized !== false) {
+                $text = $normalized;
+            }
+        }
+        return (string) preg_replace('/[^\x00-\x7F]+/', '', $text);
+    }
+
+    /**
+     * Fold simple plurals: strip one trailing 's', never from ss/us/is
+     * endings (class, status, axis). QUERY-side only — so `fields` in a
+     * question also reaches `Field` definitions.
+     */
+    public static function lightStem(string $token): string
+    {
+        if (strlen($token) > 3
+            && str_ends_with($token, 's')
+            && !str_ends_with($token, 'ss')
+            && !str_ends_with($token, 'us')
+            && !str_ends_with($token, 'is')) {
+            return substr($token, 0, -1);
+        }
+        return $token;
+    }
+
+    /**
+     * Accent-folded lowercase alphanumeric tokens (digits kept).
+     *
+     * @return string[]
+     */
+    public static function terms(string $text): array
+    {
+        preg_match_all('/[a-z0-9]+/', self::fold($text), $matches);
+        return $matches[0];
+    }
+
+    /**
+     * Chunk source on top-level def/class/decorator/function boundaries
+     * (sentence chunking shreds code). Segments are packed up to `$maxLines`,
+     * and every chunk starts with a `# file: <path>` line so the path's tokens
+     * are indexed — 'where is the router?' should match core/Router.php by name.
+     *
+     * @return array<int, array{0:int, 1:string}> list of [index, chunkText] pairs
+     */
+    public static function chunkCode(string $text, string $path = '', int $maxLines = 60): array
+    {
+        $lines = self::splitLines($text);
+        $bounds = [];
+        foreach ($lines as $i => $line) {
+            if (preg_match(self::TOPLEVEL, $line) === 1) {
+                $bounds[] = $i;
+            }
+        }
+        if (empty($bounds) || $bounds[0] !== 0) {
+            array_unshift($bounds, 0);
+        }
+        // Build segments between consecutive boundaries.
+        $segments = [];
+        $ends = array_slice($bounds, 1);
+        $ends[] = count($lines);
+        foreach ($bounds as $k => $start) {
+            $segments[] = array_slice($lines, $start, $ends[$k] - $start);
+        }
+
+        $header = $path !== '' ? "# file: {$path}" : null;
+        $out = [];
+        foreach (self::pack($segments, $maxLines) as $i => $chunkLines) {
+            $body = implode("\n", $header !== null ? array_merge([$header], $chunkLines) : $chunkLines);
+            $out[] = [$i, $body];
+        }
+        return $out;
+    }
+
+    /**
+     * Chunk prose/docs into sentence-packed windows of at most `$maxWords`
+     * words.
+     *
+     * @return array<int, array{0:int, 1:string}> list of [index, chunkText] pairs
+     */
+    public static function chunkText(string $text, int $maxWords = 350): array
+    {
+        // Sentence boundary = end punctuation FOLLOWED BY whitespace/EOL, or a
+        // newline. NOT a bare '.', which would shred embedded code in prose
+        // ("db.fetch()" -> "db. fetch()").
+        $parts = preg_split('/(?<=[.!?])\s+|\n+/', $text);
+        if ($parts === false) {
+            $parts = [$text];
+        }
+        $sentences = [];
+        foreach ($parts as $part) {
+            $trimmed = trim($part);
+            if ($trimmed !== '') {
+                $sentences[] = $trimmed;
+            }
+        }
+
+        $chunks = [];
+        $cur = [];
+        $curWords = 0;
+        foreach ($sentences as $sentence) {
+            $wordCount = count(preg_split('/\s+/', $sentence, -1, PREG_SPLIT_NO_EMPTY) ?: []);
+            if (!empty($cur) && $curWords + $wordCount > $maxWords) {
+                $chunks[] = implode(' ', $cur);
+                $cur = [];
+                $curWords = 0;
+            }
+            $cur[] = $sentence;
+            $curWords += $wordCount;
+        }
+        if (!empty($cur)) {
+            $chunks[] = implode(' ', $cur);
+        }
+
+        $out = [];
+        foreach ($chunks as $i => $chunk) {
+            $out[] = [$i, $chunk];
+        }
+        return $out;
+    }
+
+    /**
+     * Pack line-segments into chunks of at most `$maxLines` lines,
+     * hard-splitting any single oversized segment.
+     *
+     * @param array<int, string[]> $segments
+     * @return array<int, string[]>
+     */
+    private static function pack(array $segments, int $maxLines): array
+    {
+        $chunks = [];
+        $cur = [];
+        foreach ($segments as $seg) {
+            while (count($seg) > $maxLines) {          // oversized segment: hard split
+                if (!empty($cur)) {
+                    $chunks[] = $cur;
+                    $cur = [];
+                }
+                $chunks[] = array_slice($seg, 0, $maxLines);
+                $seg = array_slice($seg, $maxLines);
+            }
+            if (!empty($cur) && count($cur) + count($seg) > $maxLines) {
+                $chunks[] = $cur;
+                $cur = [];
+            }
+            $cur = array_merge($cur, $seg);
+        }
+        if (!empty($cur)) {
+            $chunks[] = $cur;
+        }
+        return $chunks;
+    }
+
+    /**
+     * Split text into lines the way Python's str.splitlines() does: break on
+     * \r\n / \r / \n and drop exactly one trailing empty produced by a final
+     * newline (so "a\n" -> ["a"], not ["a", ""]).
+     *
+     * @return string[]
+     */
+    private static function splitLines(string $text): array
+    {
+        if ($text === '') {
+            return [];
+        }
+        $lines = preg_split('/\r\n|\r|\n/', $text);
+        if ($lines === false) {
+            return [$text];
+        }
+        if (count($lines) > 0 && end($lines) === '' && preg_match('/(\r\n|\r|\n)$/', $text) === 1) {
+            array_pop($lines);
+        }
+        return $lines;
+    }
+}

--- a/Tina4/DevAdmin.php
+++ b/Tina4/DevAdmin.php
@@ -325,6 +325,22 @@ class DevAdmin
                 Log::error('Re-discover on reload failed: ' . $e->getMessage());
             }
 
+            // Keep the code Context index LIVE on the same reload trigger:
+            // reindex just the changed file (UPSERT) so the dev-MCP code_search
+            // reflects the edit immediately. Only touches an already-built index
+            // (existingContext() never creates one); guarded so a context
+            // failure never breaks the reload. Mirrors Python's _api_reload.
+            try {
+                if (self::$reloadFile !== '') {
+                    $ctx = Context::existingContext();
+                    if ($ctx !== null) {
+                        $ctx->reindexFile(self::$reloadFile);
+                    }
+                }
+            } catch (\Throwable $e) {
+                Log::error('Context reindex on reload failed: ' . $e->getMessage());
+            }
+
             // WebSocket-primary reload: push an instant {type, file, mtime}
             // message to every browser connected on /__dev_reload. The toolbar
             // client (and the dev-admin dashboard) act on it immediately — the

--- a/Tina4/MCP.php
+++ b/Tina4/MCP.php
@@ -1889,6 +1889,34 @@ class McpDevTools
             return $spec ?? ['error' => "method not found: {$class}::{$name}"];
         }, 'Live method reflection — returns signature, params, return type, file, line.');
 
+        // ── Code/doc grounding (Tina4\Context) ───────────────────
+        // Sibling of api_* but the DUAL of it: api_* is exact structural
+        // reflection (class/method signatures); code_search is fuzzy/semantic
+        // FTS over the project's own SOURCE + docs. Use code_search for
+        // "where/how is X done in THIS codebase?" and api_* for "what's the
+        // signature of X?". Backed by a zero-dependency SQLite FTS5 index at
+        // .tina4/context.db, held as a PROCESS-WIDE shared Context so the dev
+        // reload hook can keep the SAME index fresh on every file save.
+        $codeRoot = static function () use ($projectRoot): string {
+            return is_dir($projectRoot . DIRECTORY_SEPARATOR . 'src')
+                ? $projectRoot . DIRECTORY_SEPARATOR . 'src'
+                : $projectRoot;
+        };
+        $server->registerTool('code_search', function (string $query, int $k = 5, bool $rebuild = false) use ($projectRoot, $codeRoot) {
+            $ctx = Context::defaultContext(
+                $codeRoot(),
+                $projectRoot . DIRECTORY_SEPARATOR . '.tina4' . DIRECTORY_SEPARATOR . 'context.db'
+            );
+            if (!$ctx->available) {
+                return ['error' => 'SQLite FTS5 is not available in this PHP build; code_search is disabled.'];
+            }
+            if ($rebuild) {
+                $ctx->reset();
+                $ctx->indexRoot($codeRoot());
+            }
+            return $ctx->search($query, $k);
+        }, "Fuzzy/semantic search over THIS project's source + docs (FTS5). Use for 'where/how is X done here?'; api_* for exact signatures.");
+
         // ── Project introspection ────────────────────────────────
 
         $server->registerTool('git_status', function () use ($projectRoot) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -73,6 +73,8 @@
             <file>tests/WsdlTest.php</file>
             <file>tests/MessengerTest.php</file>
             <file>tests/DevAdminTest.php</file>
+            <file>tests/ContextTest.php</file>
+            <file>tests/ContextReloadReindexTest.php</file>
             <file>tests/PortConfigTest.php</file>
             <file>tests/TemplateMethodTest.php</file>
             <file>tests/FakeDataTest.php</file>

--- a/tests/ContextReloadReindexTest.php
+++ b/tests/ContextReloadReindexTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+// DevAdmin + its secondary classes live together in DevAdmin.php and PSR-4
+// cannot autoload them individually, so force-include the file.
+require_once __DIR__ . '/../Tina4/DevAdmin.php';
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Context;
+use Tina4\DevAdmin;
+use Tina4\Request;
+use Tina4\Response;
+use Tina4\Router;
+
+/**
+ * The dev reload TRIGGER (POST /__dev/api/reload) must reindex the changed
+ * file into the shared Context so code_search reflects the edit — PHP parity
+ * with tina4-python tests/test_context.py::TestReloadReindex. Real route
+ * handler, real Context, real temp files, no mocks.
+ *
+ * Global-state discipline mirrors DevReloadWsTest: the reload path installs
+ * App + ErrorTracker global handlers, so we warm them ONCE in setUpBeforeClass
+ * (before any per-test risk snapshot; they are idempotent so re-registration
+ * adds none) and clear the Router in BOTH setUp and tearDown so this class
+ * never leaves a populated router or leaked handlers for later suites.
+ */
+class ContextReloadReindexTest extends TestCase
+{
+    /** @var string[] */
+    private array $tempDirs = [];
+    private ?string $savedCwd = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Warm the global error/exception handlers ONCE, before any per-test
+        // risk snapshot, so no individual test is charged with "newly leaking"
+        // them (ErrorTracker::register is idempotent). We deliberately do NOT
+        // construct App here: its ctor calls Auth::ensureDevSecret(), which
+        // mutates TINA4_SECRET and would poison later CSRF/JWT suites. The
+        // reload handler needs only the registered routes, not a booted App.
+        DevAdmin::register();
+    }
+
+    protected function setUp(): void
+    {
+        Context::clearShared();
+        Router::clear();
+        $this->savedCwd = getcwd() ?: null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedCwd !== null) {
+            @chdir($this->savedCwd);
+        }
+        Router::clear();
+        Context::clearShared();
+        foreach ($this->tempDirs as $dir) {
+            $this->rrmdir($dir);
+        }
+        $this->tempDirs = [];
+    }
+
+    public function testApiReloadReindexesChangedFile(): void
+    {
+        $tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'tina4ctxreload_' . bin2hex(random_bytes(6));
+        mkdir($tmp . '/src', 0777, true);
+        $this->tempDirs[] = $tmp;
+        file_put_contents($tmp . '/src/mod.php', "<?php\nfunction wombat()\n{\n    return 1;\n}\n");
+
+        chdir($tmp);
+        // Build the shared index the way code_search does — db at cwd/.tina4/context.db.
+        $db = getcwd() . '/.tina4/context.db';
+        $ctx = Context::defaultContext($tmp . '/src', $db);
+        $this->assertContains('mod.php', array_map(static fn ($r) => $r['path'], $ctx->search('wombat')));
+
+        // edit, then FIRE the reload trigger with the changed file (real handler).
+        // setUp() cleared the router, so re-register the dev-admin routes here
+        // (ErrorTracker::register is idempotent — no new global handler).
+        file_put_contents($tmp . '/src/mod.php', "<?php\nfunction giraffe()\n{\n    return 2;\n}\n");
+        DevAdmin::register();
+        $callback = null;
+        foreach (Router::getRoutes() as $route) {
+            if (($route['pattern'] ?? '') === '/__dev/api/reload' && ($route['method'] ?? '') === 'POST') {
+                $callback = $route['callback'];
+                break;
+            }
+        }
+        $this->assertNotNull($callback, 'reload route should be registered');
+        $callback(
+            Request::create('POST', '/__dev/api/reload', null, ['file' => 'src/mod.php', 'type' => 'reload']),
+            new Response(true)
+        );
+
+        $this->assertContains('mod.php', array_map(static fn ($r) => $r['path'], $ctx->search('giraffe')), 'the reload trigger must reindex the new content');
+        $this->assertNotContains('mod.php', array_map(static fn ($r) => $r['path'], $ctx->search('wombat')), 'old content must be gone after the reload reindex');
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,0 +1,430 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+// MessageLog / DevAdmin live together in DevAdmin.php and PSR-4 cannot
+// autoload the secondary classes individually, so force-include the file for
+// the reload-trigger test below.
+require_once __DIR__ . '/../Tina4/DevAdmin.php';
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Context;
+use Tina4\ContextChunker;
+use Tina4\DevAdmin;
+use Tina4\McpDevTools;
+use Tina4\McpServer;
+use Tina4\Request;
+use Tina4\Response;
+use Tina4\Router;
+
+/**
+ * Real, no-mock tests for the native Context code/doc grounding subsystem
+ * (PHP parity with tina4-python tests/test_context.py).
+ *
+ * Every test uses a REAL temp SQLite file and REAL temp source files — there
+ * is nothing to mock. They pin the behaviours the port promises:
+ *
+ *   1. ranking: a definition out-ranks a test that merely mentions the symbol
+ *      (definition-first reorder over bm25()), and source-over-tests sinks a
+ *      testlike path below non-test source;
+ *   2. reindex-on-change: indexPath is an UPSERT — new content found, the
+ *      file's old chunks gone, no row duplication;
+ *   3. reindexFile against a src/ subdir root + skip outside-root / ineligible
+ *      / skip-dir + drop-on-delete;
+ *   4. FTS5 availability guard: detected for real, and a Context that finds
+ *      FTS5 absent degrades to safe no-ops instead of crashing;
+ *   5. result shape + score ordering, doc-as-prose + vendor-dir skipping;
+ *   6. the process-wide shared singleton;
+ *   7. the dev-MCP code_search tool over a real temp project.
+ *
+ * Non-overlapping symbol names (quokka/giraffe/wombat/…) are used in ranking
+ * and reindex tests so shared FTS tokens can never cross-match into a false
+ * pass or failure.
+ */
+class ContextTest extends TestCase
+{
+    /** @var string[] */
+    private array $tempDirs = [];
+    private ?string $savedCwd = null;
+
+    protected function setUp(): void
+    {
+        Context::clearShared();
+        $this->savedCwd = getcwd() ?: null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedCwd !== null) {
+            @chdir($this->savedCwd);
+        }
+        Context::clearShared();
+        foreach ($this->tempDirs as $dir) {
+            $this->rrmdir($dir);
+        }
+        $this->tempDirs = [];
+    }
+
+    // ── helpers ─────────────────────────────────────────────────
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'tina4ctx_' . bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+        $this->tempDirs[] = $dir;
+        return $dir;
+    }
+
+    private function write(string $root, string $rel, string $body): string
+    {
+        $path = $root . DIRECTORY_SEPARATOR . $rel;
+        $parent = dirname($path);
+        if (!is_dir($parent)) {
+            mkdir($parent, 0777, true);
+        }
+        file_put_contents($path, $body);
+        return $path;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    /** @param array<int, array{path:string, score:float, snippet:string}> $res */
+    private function paths(array $res): array
+    {
+        return array_map(static fn ($r) => $r['path'], $res);
+    }
+
+    // ── 1. ranking — definition above a test that mentions the symbol ──
+
+    public function testDefinitionOutranksTestThatMentionsSymbol(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $this->write($root, 'src/inventory.php',
+            "<?php\nfunction quokka_stocktake(\$item)\n{\n    // tally current stock for an item\n    return \$item;\n}\n");
+        // A test file that MENTIONS quokka_stocktake many times (bm25 loves this)
+        // but does NOT define it — it must not out-rank the definition. Its class
+        // (InventoryAudit) and method names share no token with the symbol.
+        $this->write($root, 'tests/InventoryAudit.php',
+            "<?php\nclass InventoryAudit\n{\n    public function auditRun()\n    {\n"
+            . "        assert(quokka_stocktake(1));\n        assert(quokka_stocktake(2));\n"
+            . "        assert(quokka_stocktake(3));\n        assert(quokka_stocktake(4));\n    }\n}\n");
+
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $this->assertGreaterThan(0, $ctx->indexRoot($root));
+
+        $res = $ctx->search('quokka_stocktake', 5);
+        $paths = $this->paths($res);
+
+        // both files surface
+        $this->assertTrue(
+            (bool) array_filter($paths, static fn ($p) => str_ends_with($p, 'inventory.php') && !str_contains($p, 'test')),
+            'definition file should surface: ' . json_encode($paths)
+        );
+        $this->assertTrue(
+            (bool) array_filter($paths, static fn ($p) => str_contains($p, 'InventoryAudit')),
+            'test file should surface: ' . json_encode($paths)
+        );
+
+        // the definition (non-test source) ranks ABOVE the test file
+        $srcIdx = $this->firstIndex($res, static fn ($p) => str_ends_with($p, 'inventory.php') && !str_contains($p, 'test'));
+        $testIdx = $this->firstIndex($res, static fn ($p) => str_contains($p, 'InventoryAudit'));
+        $this->assertNotNull($srcIdx);
+        $this->assertNotNull($testIdx);
+        $this->assertLessThan($testIdx, $srcIdx, 'definition should out-rank the test: ' . json_encode($paths));
+
+        // and the very top hit is the definition, not a test file
+        $this->assertStringNotContainsString('test', $res[0]['path'], json_encode($paths));
+        $ctx->close();
+    }
+
+    /** Source-over-tests: a testlike path sinks below non-test source that
+     *  matches equally well (neither defines the queried symbol). */
+    public function testSourceOverTestsSinksTestlikePath(): void
+    {
+        $root = $this->tempDir() . '/app';
+        // A doc (non-test) and an example file (testlike path) that BOTH merely
+        // mention the symbol — neither defines it. is_test is the only
+        // differentiator, so the doc must rank above the example.
+        $this->write($root, 'src/guide.md',
+            "# Overview\n\nThe flibbertigibbet subsystem coordinates the pipeline across nodes.\n");
+        $this->write($root, 'example/Sample.php',
+            "<?php\n// demonstrates flibbertigibbet usage in a sample\n\$out = flibbertigibbet_helper();\n");
+
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($root);
+
+        $res = $ctx->search('flibbertigibbet', 5);
+        $paths = $this->paths($res);
+        $docIdx = $this->firstIndex($res, static fn ($p) => str_ends_with($p, 'guide.md'));
+        $exampleIdx = $this->firstIndex($res, static fn ($p) => str_contains($p, 'example/'));
+        $this->assertNotNull($docIdx, 'doc should surface: ' . json_encode($paths));
+        $this->assertNotNull($exampleIdx, 'example should surface: ' . json_encode($paths));
+        $this->assertLessThan($exampleIdx, $docIdx, 'non-test source should out-rank the testlike example: ' . json_encode($paths));
+        $ctx->close();
+    }
+
+    // ── 2. reindex-on-change — UPSERT: new found, old gone, no duplication ──
+
+    public function testReindexOnChangeIsUpsert(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $file = $this->write($root, 'src/mod.php', "<?php\nfunction wombat()\n{\n    return 1;\n}\n");
+
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexPath($file, 'src/mod.php');
+
+        $this->assertContains('src/mod.php', $this->paths($ctx->search('wombat')), 'wombat should be found first');
+        $rowsBefore = $ctx->count();
+
+        // edit the file: wombat -> giraffe, then re-index just this file
+        file_put_contents($file, "<?php\nfunction giraffe()\n{\n    return 2;\n}\n");
+        $ctx->indexPath($file, 'src/mod.php');
+
+        // new content retrievable
+        $this->assertContains('src/mod.php', $this->paths($ctx->search('giraffe')), 'giraffe should be found after reindex');
+        // OLD content for this file is gone (upsert deleted the stale chunks)
+        $this->assertNotContains('src/mod.php', $this->paths($ctx->search('wombat')), 'wombat chunks must be gone');
+        // no duplication — same file, same chunk count => same total rows
+        $this->assertSame($rowsBefore, $ctx->count(), 'UPSERT must delete-then-insert, not append');
+        $ctx->close();
+    }
+
+    public function testIndexPathSecondCallReplacesNotAppends(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $file = $this->write($root, 'src/dup.php', "<?php\nfunction only_one()\n{\n    return 42;\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexPath($file, 'src/dup.php');
+        $n1 = $ctx->count();
+        $ctx->indexPath($file, 'src/dup.php');
+        $this->assertSame($n1, $ctx->count(), 're-indexing an unchanged file must not append duplicates');
+        $ctx->close();
+    }
+
+    // ── 3. FTS5 availability guard ──────────────────────────────
+
+    public function testFts5AvailableOnThisBuild(): void
+    {
+        // real detector — modern PDO SQLite ships FTS5, so it must report true
+        $this->assertTrue(Context::fts5Available());
+    }
+
+    public function testContextDegradesGracefullyWithoutFts5(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $this->write($root, 'src/x.php', "<?php\nfunction y()\n{\n    return 1;\n}\n");
+
+        // inject a predicate that reports FTS5 as ABSENT — exercises the real
+        // graceful-degradation branch (no mocking of PDO or files).
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db', static fn () => false);
+        $this->assertFalse($ctx->available);
+        $this->assertSame(0, $ctx->indexRoot($root));
+        $this->assertSame(0, $ctx->indexPath($root . '/src/x.php', 'src/x.php'));
+        $this->assertSame([], $ctx->search('anything'));
+        $ctx->close();
+
+        // a normal Context on this build IS available
+        $ok = new Context($this->tempDir() . '/.tina4/ok.db');
+        $this->assertTrue($ok->available);
+        $ok->close();
+    }
+
+    // ── 4. result shape, score ordering, doc chunking, dir skipping ──
+
+    public function testSearchResultShapeAndScoreOrdering(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $this->write($root, 'src/Widget.php',
+            "<?php\nfunction build_widget(\$spec)\n{\n    return new Widget(\$spec);\n}\n\nclass Widget\n{\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($root);
+
+        $res = $ctx->search('build_widget', 5);
+        $this->assertNotEmpty($res, 'expected at least one hit');
+        foreach ($res as $r) {
+            $this->assertArrayHasKey('path', $r);
+            $this->assertArrayHasKey('score', $r);
+            $this->assertArrayHasKey('snippet', $r);
+            $this->assertIsFloat($r['score']);
+            $this->assertIsString($r['snippet']);
+            $this->assertNotSame('', $r['snippet']);
+        }
+        // higher score = better; results are sorted descending
+        $scores = array_map(static fn ($r) => $r['score'], $res);
+        $sorted = $scores;
+        rsort($sorted);
+        $this->assertSame($sorted, $scores, json_encode($scores));
+        $ctx->close();
+    }
+
+    public function testIndexesDocsAsProseAndSkipsVendorDirs(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $this->write($root, 'docs/guide.md',
+            "# Overview\n\nThe whirligig subsystem manages the flux capacitor and its temporal bindings.\n");
+        // these live under dirs the walk skips — they must NOT be indexed
+        $this->write($root, '__pycache__/junk.py', "def whirligig_flux_capacitor(): pass\n");
+        $this->write($root, 'node_modules/lib.js', "function whirligigFluxCapacitor(){}\n");
+        $this->write($root, 'vendor/pkg/Thing.php', "<?php\nfunction whirligig_flux_capacitor(){}\n");
+
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($root);
+
+        $paths = $this->paths($ctx->search('whirligig flux capacitor', 5));
+        $this->assertTrue((bool) array_filter($paths, static fn ($p) => str_ends_with($p, 'guide.md')), json_encode($paths));
+        $this->assertEmpty(array_filter($paths, static fn ($p) => str_contains($p, '__pycache__')), json_encode($paths));
+        $this->assertEmpty(array_filter($paths, static fn ($p) => str_contains($p, 'node_modules')), json_encode($paths));
+        $this->assertEmpty(array_filter($paths, static fn ($p) => str_contains($p, 'vendor')), json_encode($paths));
+        $ctx->close();
+    }
+
+    public function testEmptyOrWhitespaceQueryReturnsEmpty(): void
+    {
+        $root = $this->tempDir() . '/app';
+        $this->write($root, 'src/a.php', "<?php\nfunction a()\n{\n    return 1;\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($root);
+        $this->assertSame([], $ctx->search(''));
+        $this->assertSame([], $ctx->search('   '));
+        $ctx->close();
+    }
+
+    // ── 5. reindexFile — UPSERT against the index root ──────────
+
+    public function testReindexFileUpsertsAgainstASubdirRoot(): void
+    {
+        // The reload trigger reports project-root-relative paths ('src/mod.php'),
+        // but the index root may be a subdir (src/); reindexFile must relabel and
+        // upsert correctly.
+        $tmp = $this->tempDir();
+        $this->write($tmp, 'src/mod.php', "<?php\nfunction wombat()\n{\n    return 1;\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($tmp . '/src');                 // root = src/, label = "mod.php"
+        $this->assertContains('mod.php', $this->paths($ctx->search('wombat')));
+
+        file_put_contents($tmp . '/src/mod.php', "<?php\nfunction giraffe()\n{\n    return 2;\n}\n");
+        chdir($tmp);
+        $this->assertGreaterThanOrEqual(1, $ctx->reindexFile('src/mod.php'));   // project-root-relative
+
+        $this->assertContains('mod.php', $this->paths($ctx->search('giraffe')), 'new content found');
+        $this->assertNotContains('mod.php', $this->paths($ctx->search('wombat')), 'old content gone');
+        $ctx->close();
+    }
+
+    public function testReindexFileSkipsOutsideRootIneligibleAndSkipdirs(): void
+    {
+        $tmp = $this->tempDir();
+        $this->write($tmp, 'src/a.php', "<?php\nfunction aardvark()\n{\n    return 1;\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($tmp . '/src');
+        chdir($tmp);
+
+        $this->write($tmp, 'README.md', "# top-level, outside src/\n");
+        $this->assertSame(-1, $ctx->reindexFile('README.md'));            // outside the index root
+
+        $this->write($tmp, 'src/data.bin', 'x');
+        $this->assertSame(-1, $ctx->reindexFile('src/data.bin'));         // ineligible extension
+
+        $this->write($tmp, 'src/__pycache__/j.php', "<?php\nfunction j(){}\n");
+        $this->assertSame(-1, $ctx->reindexFile('src/__pycache__/j.php')); // skip-dir
+        $ctx->close();
+    }
+
+    public function testReindexFileDropsADeletedFile(): void
+    {
+        $tmp = $this->tempDir();
+        $file = $this->write($tmp, 'src/gone.php', "<?php\nfunction unique_gone_sym()\n{\n    return 1;\n}\n");
+        $ctx = new Context($this->tempDir() . '/.tina4/context.db');
+        $ctx->indexRoot($tmp . '/src');
+        $this->assertContains('gone.php', $this->paths($ctx->search('unique_gone_sym')));
+
+        unlink($file);
+        chdir($tmp);
+        $this->assertSame(0, $ctx->reindexFile('src/gone.php'));           // delete → drop rows
+
+        $this->assertSame([], $ctx->search('unique_gone_sym'), "deleted file's chunks must be gone");
+        $ctx->close();
+    }
+
+    // ── 6. process-wide shared singleton ────────────────────────
+
+    public function testDefaultContextIsASharedSingleton(): void
+    {
+        Context::clearShared();
+        $tmp = $this->tempDir();
+        $db = $tmp . '/.tina4/ctx.db';
+        $this->write($tmp, 'src/x.php', "<?php\nfunction findme_sym()\n{\n    return 1;\n}\n");
+
+        $a = Context::defaultContext($tmp . '/src', $db);
+        $this->assertSame($a, Context::defaultContext(null, $db), 'same db path → same instance');
+        $this->assertSame($a, Context::existingContext($db));
+        $this->assertNull(Context::existingContext($tmp . '/nope.db'));
+        $this->assertTrue((bool) array_filter($this->paths($a->search('findme_sym')), static fn ($p) => str_contains($p, 'x.php')));
+
+        $a->close();
+        Context::clearShared();
+    }
+
+    // ── 7. the dev-MCP code_search tool over a real temp project ──
+
+    public function testCodeSearchToolRegisteredAndFindsSymbol(): void
+    {
+        $tmp = $this->tempDir();
+        mkdir($tmp . '/src', 0777, true);
+        file_put_contents($tmp . '/src/service.php',
+            "<?php\nfunction widget_factory(\$name)\n{\n    // create a configured widget\n    return ['name' => \$name];\n}\n");
+
+        chdir($tmp);
+        $server = new McpServer('/test-code-search', 'code_search test');
+        McpDevTools::register($server);
+
+        // tool is registered (sibling of api_search)
+        $listed = json_decode($server->handleMessage([
+            'jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list', 'params' => [],
+        ]), true);
+        $names = array_map(static fn ($t) => $t['name'], $listed['result']['tools']);
+        $this->assertContains('code_search', $names, json_encode($names));
+
+        $resp = json_decode($server->handleMessage([
+            'jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/call',
+            'params' => ['name' => 'code_search', 'arguments' => ['query' => 'widget_factory']],
+        ]), true);
+        $this->assertArrayHasKey('result', $resp, json_encode($resp));
+        $payload = json_decode($resp['result']['content'][0]['text'], true);
+        $this->assertIsArray($payload, json_encode($resp));
+        $paths = array_map(static fn ($r) => $r['path'], $payload);
+        $this->assertTrue((bool) array_filter($paths, static fn ($p) => str_ends_with($p, 'service.php')), json_encode($payload));
+    }
+
+    /** @param callable(string):bool $pred */
+    private function firstIndex(array $res, callable $pred): ?int
+    {
+        foreach ($res as $i => $r) {
+            if ($pred($r['path'])) {
+                return $i;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -226,7 +226,7 @@ class ContextTest extends TestCase
 
     public function testFts5AvailableOnThisBuild(): void
     {
-        // real detector — modern PDO SQLite ships FTS5, so it must report true
+        // real detector — modern SQLite (sqlite3 ext) ships FTS5, so it must report true
         $this->assertTrue(Context::fts5Available());
     }
 
@@ -236,7 +236,7 @@ class ContextTest extends TestCase
         $this->write($root, 'src/x.php', "<?php\nfunction y()\n{\n    return 1;\n}\n");
 
         // inject a predicate that reports FTS5 as ABSENT — exercises the real
-        // graceful-degradation branch (no mocking of PDO or files).
+        // graceful-degradation branch (no mocking of SQLite3 or files).
         $ctx = new Context($this->tempDir() . '/.tina4/context.db', static fn () => false);
         $this->assertFalse($ctx->available);
         $this->assertSame(0, $ctx->indexRoot($root));


### PR DESCRIPTION
Native SQLite FTS5 `Context` + `code_search` dev-MCP tool + reindex-on-change, using the framework's own SQLite binding. Real no-mock tests, zero new deps. Parity with tina4-python. Skill updated with code_search in the grounding ladder. Independently re-verified by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)