### PR TITLE
migration: canonical migrations/ path (default + legacy fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,7 +584,7 @@ $api->setBasicAuth(string $username, string $password): void
 ### Migration — Database migrations
 
 ```php
-$migration = new \Tina4\Migration(DatabaseAdapter $db, string $migrationsDir = "src/migrations", string $delimiter = ";")
+$migration = new \Tina4\Migration(DatabaseAdapter $db, string $migrationsDir = "migrations", string $delimiter = ";")
 $migration->migrate(): array
 ```
 

--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -22,7 +22,9 @@ use Tina4\Database\DatabaseAdapter;
  *   - YYYYMMDDHHMMSS_description.down.sql
  *   - 000001_description.down.sql
  *
- * Located in src/migrations/ by default.
+ * Located in migrations/ (project root) by default — the one canonical location, matching
+ * createMigration(), App auto-migrate, the CLI, and the Python reference. Legacy src/migrations/
+ * is still honoured as a fallback.
  * Tracks applied migrations in the tina4_migration table.
  */
 class Migration
@@ -36,11 +38,23 @@ class Migration
     /** Cached probe: does the tracking table still carry the older-v3 `migration` column? */
     private ?bool $legacyMigrationColumn = null;
 
+    /** @var string Resolved migrations directory — canonical migrations/ at the project root */
+    private readonly string $migrationsDir;
+
     public function __construct(
         private readonly DatabaseAdapter $db,
-        private readonly string $migrationsDir = 'src/migrations',
+        string $migrationsDir = 'migrations',
         private readonly string $delimiter = ';',
     ) {
+        // Canonical location is migrations/ (project root) — matches createMigration(), App
+        // auto-migrate, the CLI, and the Python reference. Fall back to the legacy
+        // src/migrations/ ONLY when the default was taken, migrations/ is absent, and a legacy
+        // src/migrations/ exists, so existing projects keep working (with a deprecation nudge).
+        if ($migrationsDir === 'migrations' && !is_dir('migrations') && is_dir('src/migrations')) {
+            Log::warning('Migration: using legacy src/migrations/ — move migrations to migrations/ (project root).');
+            $migrationsDir = 'src/migrations';
+        }
+        $this->migrationsDir = $migrationsDir;
         $this->ensureMigrationsTable();
     }
 

--- a/tests/MigrationDefaultPathTest.php
+++ b/tests/MigrationDefaultPathTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Tina4 — Migration default-path resolution.
+ *
+ * The Migration constructor default was 'src/migrations' while createMigration(), the CLI,
+ * App auto-migrate, Metrics, MCP, and the Python reference all use 'migrations/' (project root).
+ * The default is now 'migrations/', with a legacy 'src/migrations/' fallback. Real SQLite, no mocks.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Database\SQLite3Adapter;
+use Tina4\Migration;
+
+class MigrationDefaultPathTest extends TestCase
+{
+    private string $projectDir;
+    private string $oldCwd;
+
+    protected function setUp(): void
+    {
+        $this->oldCwd = getcwd();
+        $this->projectDir = sys_get_temp_dir() . '/tina4_mig_default_' . uniqid();
+        mkdir($this->projectDir, 0755, true);
+        chdir($this->projectDir);           // migrations dir is resolved relative to CWD
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->oldCwd);
+        $this->rmrf($this->projectDir);
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->rmrf($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    private function writeMigration(string $dir, string $table): string
+    {
+        mkdir($dir, 0755, true);
+        $name = '000001_create_' . $table . '.sql';
+        file_put_contents($dir . '/' . $name, "CREATE TABLE {$table} (id INTEGER PRIMARY KEY);");
+        return $name;
+    }
+
+    public function testDefaultUsesMigrationsAtProjectRoot(): void
+    {
+        $name = $this->writeMigration('migrations', 'widgets_root');
+        $res = (new Migration(new SQLite3Adapter(':memory:')))->migrate();   // no dir -> 'migrations'
+        $this->assertContains($name, $res['applied'], 'default should apply from migrations/');
+    }
+
+    public function testLegacySrcMigrationsFallback(): void
+    {
+        $name = $this->writeMigration('src/migrations', 'widgets_legacy');   // only the legacy layout
+        $res = (new Migration(new SQLite3Adapter(':memory:')))->migrate();   // migrations/ absent -> fallback
+        $this->assertContains($name, $res['applied'], 'should fall back to legacy src/migrations/');
+    }
+
+    public function testMigrationsRootWinsWhenBothExist(): void
+    {
+        $rootName = $this->writeMigration('migrations', 'widgets_win');
+        $this->writeMigration('src/migrations', 'widgets_lose');
+        $res = (new Migration(new SQLite3Adapter(':memory:')))->migrate();
+        $this->assertContains($rootName, $res['applied']);
+        $this->assertNotContains('000001_create_widgets_lose.sql', $res['applied'],
+            'canonical migrations/ must win over legacy src/migrations/');
+    }
+
+    public function testExplicitDirIsRespected(): void
+    {
+        $name = $this->writeMigration('custom_migs', 'widgets_custom');
+        $res = (new Migration(new SQLite3Adapter(':memory:'), 'custom_migs'))->migrate();
+        $this->assertContains($name, $res['applied']);
+    }
+}


### PR DESCRIPTION
Held footgun fix — bundling with the 3.13.62 Context release. Migration default path canonicalized with a legacy fallback; real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)