### PR TITLE
feat(cli): self-describing `commands` subcommand + single-source command registry (PHP)

### DIFF
--- a/bin/tina4php
+++ b/bin/tina4php
@@ -343,9 +343,206 @@ function resolveHostPort(?string $cliArg = null): array
     return [$host, $port];
 }
 
+// ── Command surface — single source of truth ──────────────────────────────
+//
+// ONE registry per surface drives the human help (tina4RenderHelp), the machine
+// manifest (`commands --json` / tina4CommandsManifest), the `generate` sub-list,
+// AND gates dispatch below (an unknown command is one absent from $TINA4_COMMANDS).
+// Add a command in ONE place and it shows up in help, discovery, and dispatch —
+// there is no second list to keep in sync. Mirrors the Python master's
+// COMMANDS / GENERATORS registries (tina4_python/cli/__init__.py).
+//
+//   $TINA4_GENERATORS[name] = ['usage' => str, 'summary' => str]
+//   $TINA4_COMMANDS[name]   = ['summary' => str,
+//                              'usage'?       => str,    // human-help arg hint only
+//                              'args'?        => [str],  // positional args -> manifest ("x?" = optional)
+//                              'subcommands'? => [str]]   // sub-names -> manifest (generate)
+
+/**
+ * Resolve the framework version WITHOUT booting the app or loading heavy classes.
+ *
+ * tina4: deliberately mirrors \Tina4\App::resolveVersion() (composer.json ->
+ * installed.json) rather than calling it, so `commands` stays boot-free — the
+ * tina4 Rust client calls it on every `tina4 --help`, in any directory. Both read
+ * the same package metadata, so the reported version matches the running app's.
+ */
+function tina4FrameworkVersion(string $frameworkRoot): string
+{
+    $composer = $frameworkRoot . '/composer.json';
+    if (is_file($composer)) {
+        $data = json_decode((string)file_get_contents($composer), true);
+        if (!empty($data['version'])) {
+            return (string)$data['version'];
+        }
+    }
+    // Packagist/git installs carry the version in composer's installed.json instead.
+    foreach ([$frameworkRoot . '/../../composer/installed.json',
+              $frameworkRoot . '/vendor/composer/installed.json'] as $installed) {
+        if (is_file($installed)) {
+            $data = json_decode((string)file_get_contents($installed), true);
+            foreach ((array)($data['packages'] ?? $data) as $pkg) {
+                if (($pkg['name'] ?? '') === 'tina4stack/tina4php') {
+                    return (string)($pkg['version'] ?? '0.0.0');
+                }
+            }
+        }
+    }
+    return '0.0.0';
+}
+
+/**
+ * Build the machine-readable manifest of the CLI's command surface.
+ *
+ * Pure data: reads only the $TINA4_COMMANDS registry + the resolved version — no
+ * bootstrap, no DB, no app imports. This is exactly what `commands --json`
+ * serialises and what the tina4 Rust client consumes to discover this framework's
+ * commands. Shape (identical to the Python master):
+ *
+ *   {framework:"php", version:"<x.y.z>",
+ *    commands:[{name, summary, args?, subcommands?}, ...]}
+ */
+function tina4CommandsManifest(array $commands, string $version): array
+{
+    $list = [];
+    foreach ($commands as $name => $spec) {
+        $entry = ['name' => $name, 'summary' => $spec['summary']];
+        if (!empty($spec['args'])) {
+            $entry['args'] = array_values($spec['args']);
+        }
+        if (!empty($spec['subcommands'])) {
+            $entry['subcommands'] = array_values($spec['subcommands']);
+        }
+        $list[] = $entry;
+    }
+    return ['framework' => 'php', 'version' => $version, 'commands' => $list];
+}
+
+/**
+ * Render the human-readable help — generated from the SAME registries that drive
+ * dispatch and the manifest, so the help can never drift from what the CLI does.
+ */
+function tina4RenderHelp(array $commands, array $generators): string
+{
+    $commandRows = [];
+    foreach ($commands as $name => $spec) {
+        $commandRows[] = [trim($name . ' ' . ($spec['usage'] ?? '')), $spec['summary']];
+    }
+    $generatorRows = [];
+    foreach ($generators as $name => $spec) {
+        $generatorRows[] = [trim('generate ' . $name . ' ' . ($spec['usage'] ?? '')), $spec['summary']];
+    }
+    // Align summaries in a column; a left cell longer than the cap overflows
+    // cleanly (2-space gap) rather than pushing every other summary out.
+    $pad = 0;
+    foreach (array_merge($commandRows, $generatorRows) as [$left,]) {
+        $pad = max($pad, strlen($left));
+    }
+    $pad = min(46, $pad);
+    $row = static function (string $left, string $summary) use ($pad): string {
+        $gap = strlen($left) <= $pad ? $pad : strlen($left);
+        return '  ' . str_pad($left, $gap) . '  ' . $summary;
+    };
+
+    $lines = ['', 'Tina4 PHP CLI v3', '', 'Usage: tina4php <command> [options]', '', 'Commands:'];
+    foreach ($commandRows as [$left, $summary]) {
+        $lines[] = $row($left, $summary);
+    }
+    $lines[] = '';
+    $lines[] = 'Generators:';
+    foreach ($generatorRows as [$left, $summary]) {
+        $lines[] = $row($left, $summary);
+    }
+    $lines = array_merge($lines, [
+        '',
+        'Scaffolding-first: logic-shaped generators emit wiring + an AI-FILL placeholder',
+        '(throw \\RuntimeException) where the custom logic goes; CRUD-shaped ones emit',
+        'working code. Writes are secure by default — use --public to open them.',
+        '',
+        'Field types: string, int, float, bool, text, datetime, blob',
+        'Table names: singular by default (Product -> product)',
+        '',
+        'https://tina4.com',
+        '',
+    ]);
+    return implode("\n", $lines) . "\n";
+}
+
+/**
+ * Render the default (non-JSON) `commands` output — a readable command list.
+ * Reads the already-built manifest, so it can never disagree with `--json`.
+ */
+function tina4RenderCommands(array $manifest): string
+{
+    $width = 0;
+    foreach ($manifest['commands'] as $command) {
+        $width = max($width, strlen($command['name']));
+    }
+    $lines = ['', "Tina4 {$manifest['framework']} — {$manifest['version']}", ''];
+    foreach ($manifest['commands'] as $command) {
+        $lines[] = '  ' . str_pad($command['name'], $width) . '  ' . $command['summary'];
+        if (!empty($command['subcommands'])) {
+            $lines[] = '  ' . str_repeat(' ', $width) . '    ' . implode(', ', $command['subcommands']);
+        }
+    }
+    $lines[] = '';
+    return implode("\n", $lines) . "\n";
+}
+
+$TINA4_GENERATORS = [
+    'model'      => ['usage' => '<Name> [--fields "name:string,price:float"]', 'summary' => 'ORM model + matching migration'],
+    'route'      => ['usage' => '<name> [--model Name] [--public]',            'summary' => 'CRUD route file, secure by default (--public opens writes)'],
+    'crud'       => ['usage' => '<Name> [--fields "..."] [--public]',           'summary' => 'Model + migration + routes + form + view + test'],
+    'migration'  => ['usage' => '<description>',                                'summary' => 'Timestamped migration file'],
+    'middleware' => ['usage' => '<Name>',                                       'summary' => 'Middleware with before/after hooks'],
+    'test'       => ['usage' => '<name> [--model Name]',                        'summary' => 'PHPUnit test file'],
+    'form'       => ['usage' => '<Name> [--fields "..."]',                      'summary' => 'Form template with typed inputs'],
+    'view'       => ['usage' => '<Name> [--fields "..."]',                      'summary' => 'List + detail view templates'],
+    'auth'       => ['usage' => '',                                            'summary' => 'Login/register routes + User model + templates'],
+    'service'    => ['usage' => '<Name> [--every 5m | --cron "..."]',           'summary' => 'Scheduled ServiceRunner task (src/services/)'],
+    'queue'      => ['usage' => '<topic>',                                      'summary' => 'Producer + consumer worker (src/services/)'],
+    'validator'  => ['usage' => '<Name>',                                       'summary' => 'Request-body Validator (src/validators/)'],
+    'seeder'     => ['usage' => '<Model>',                                      'summary' => 'FakeData seeder (src/seeds/)'],
+    'websocket'  => ['usage' => '<path>',                                       'summary' => 'Router::websocket handler (src/routes/)'],
+    'listener'   => ['usage' => '<event>',                                      'summary' => 'Events::on listener (src/listeners/)'],
+];
+
+$TINA4_COMMANDS = [
+    'init'             => ['usage' => '[dir]',            'args' => ['dir?'],        'summary' => 'Scaffold a new project'],
+    'serve'            => ['usage' => '[host:port|port]',                            'summary' => 'Start dev server (default: 0.0.0.0:7145)'],
+    'start'            => [                                                          'summary' => 'Alias for serve'],
+    'migrate'          => [                                                          'summary' => 'Run pending migrations'],
+    'migrate:create'   => ['usage' => '<desc>',           'args' => ['description'], 'summary' => 'Create a migration file'],
+    'migrate:rollback' => [                                                          'summary' => 'Rollback last batch'],
+    'migrate:status'   => [                                                          'summary' => 'Show migration status'],
+    'seed'             => [                                                          'summary' => 'Run seeders from src/seeds/'],
+    'routes'           => [                                                          'summary' => 'List all registered routes'],
+    'metrics'          => ['usage' => '[--top N] [--json] [--fail-on warn|error] [--path DIR]', 'summary' => 'Rank top code-quality offenders'],
+    'test'             => [                                                          'summary' => 'Run test suite'],
+    'build'            => [                                                          'summary' => 'Build distributable package'],
+    'generate'         => ['usage' => '<what> <name> [options]', 'subcommands' => array_keys($TINA4_GENERATORS), 'summary' => 'Generate scaffolding (see Generators below)'],
+    'ai'               => ['usage' => '[--all]',                                     'summary' => 'Detect AI tools and install context'],
+    'console'          => [                                                          'summary' => 'Interactive PHP REPL with Tina4 loaded'],
+    'commands'         => ['usage' => '[--json]',                                    'summary' => 'List available commands (add --json for machine form)'],
+    'help'             => [                                                          'summary' => 'Show this help'],
+];
+
 // ── Parse command ──
 $command = $argv[1] ?? 'help';
 $args = array_slice($argv, 2);
+
+// Flag-style help aliases normalise to the 'help' command.
+if ($command === '--help' || $command === '-h') {
+    $command = 'help';
+}
+
+// The registry is the single source of truth for the command surface: a command
+// it does not declare is unknown. Mirrors the Python master's main(), which
+// prints "Unknown command" then falls back to help.
+if (!isset($TINA4_COMMANDS[$command])) {
+    echo "Unknown command: {$command}\n";
+    echo tina4RenderHelp($TINA4_COMMANDS, $TINA4_GENERATORS);
+    exit(0);
+}
 
 switch ($command) {
 
@@ -963,8 +1160,9 @@ DOCKERFILE;
     // ────────────────────────────────────────────
     case 'generate':
         $what = $args[0] ?? null;
-        $allGenerators = 'model, route, crud, migration, middleware, test, form, view, auth, '
-            . 'service, queue, validator, seeder, websocket, listener';
+        // Single source: the $TINA4_GENERATORS registry drives this list, the
+        // help text, and the manifest's generate.subcommands (no separate copy).
+        $allGenerators = implode(', ', array_keys($TINA4_GENERATORS));
         if (!$what) {
             echo "Usage: tina4php generate <what> <name> [options]\n";
             echo "  Generators: {$allGenerators}\n";
@@ -1096,53 +1294,27 @@ DOCKERFILE;
         break;
 
     // ────────────────────────────────────────────
-    // HELP
+    // COMMANDS — Self-describing command surface (for the tina4 client)
+    // ────────────────────────────────────────────
+    // CHEAP + side-effect-free by contract: prints only the static registry + the
+    // resolved version. It never bootstraps the app, opens a DB, runs migrations,
+    // or autoloads framework/app classes — the tina4 Rust client calls it on every
+    // `tina4 --help`, in any directory, so it stays instant and safe to run anywhere.
+    case 'commands':
+        $manifest = tina4CommandsManifest($TINA4_COMMANDS, tina4FrameworkVersion((string)$frameworkRoot));
+        if (in_array('--json', $args, true)) {
+            echo json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
+        } else {
+            echo tina4RenderCommands($manifest);
+        }
+        break;
+
+    // ────────────────────────────────────────────
+    // HELP  (rendered from the $TINA4_COMMANDS / $TINA4_GENERATORS registries)
     // ────────────────────────────────────────────
     case 'help':
-    case '--help':
-    case '-h':
     default:
-        echo "Tina4 PHP CLI v3\n\n";
-        echo "Usage: tina4php <command> [options]\n\n";
-        echo "Commands:\n";
-        echo "  init [dir]              Scaffold a new project\n";
-        echo "  serve [host:port|port]   Start dev server (default: 0.0.0.0:7145)\n";
-        echo "  start [host:port|port]   Alias for serve\n";
-        echo "  migrate                 Run pending migrations\n";
-        echo "  migrate:create <desc>   Create a migration file\n";
-        echo "  migrate:rollback        Rollback last batch\n";
-        echo "  migrate:status          Show migration status\n";
-        echo "  seed                    Run seeders from src/seeds/\n";
-        echo "  routes                  List all registered routes\n";
-        echo "  metrics [--top N] [--json] [--fail-on warn|error] [--path DIR]  Rank top code-quality offenders\n";
-        echo "  test                    Run test suite\n";
-        echo "  build                   Build distributable package\n";
-        echo "  generate <what> <name>  Generate scaffolding\n";
-        echo "  ai [--all]              Detect AI tools and install context\n";
-        echo "  console                 Interactive PHP REPL with Tina4 loaded\n";
-        echo "  help                    Show this help\n";
-        echo "\nGenerators:\n";
-        echo "  generate model <Name> [--fields \"name:string,price:float\"]\n";
-        echo "  generate route <name> [--model Name] [--public]   Writes secure by default; --public opens them\n";
-        echo "  generate crud <Name> [--fields \"...\"] [--public]   Model + migration + routes + form + view + test\n";
-        echo "  generate migration <description>\n";
-        echo "  generate middleware <Name>\n";
-        echo "  generate test <name>\n";
-        echo "  generate form <Name> [--fields \"...\"]   Form template with typed inputs\n";
-        echo "  generate view <Name> [--fields \"...\"]   List + detail templates\n";
-        echo "  generate auth                           Login/register routes + User model + templates\n";
-        echo "  generate service <Name> [--every 5m | --cron \"...\"]   Scheduled ServiceRunner task (src/services/)\n";
-        echo "  generate queue <topic>                  Producer + consumer worker (src/services/)\n";
-        echo "  generate validator <Name>               Request-body Validator (src/validators/)\n";
-        echo "  generate seeder <Model>                 FakeData seeder (src/seeds/)\n";
-        echo "  generate websocket <path>               Router::websocket handler (src/routes/)\n";
-        echo "  generate listener <event>               Events::on listener (src/listeners/)\n";
-        echo "\nScaffolding-first: logic-shaped generators emit wiring + an AI-FILL placeholder\n";
-        echo "(throw \\RuntimeException) where the custom logic goes; CRUD-shaped ones emit\n";
-        echo "working code. Writes are secure by default — use --public to open them.\n";
-        echo "\nField types: string, int, float, bool, text, datetime, blob\n";
-        echo "Table names: singular by default (Product -> product)\n";
-        echo "\nhttps://tina4.com\n";
+        echo tina4RenderHelp($TINA4_COMMANDS, $TINA4_GENERATORS);
         break;
 }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -84,6 +84,7 @@
             <file>tests/MetricsTest.php</file>
             <file>tests/MetricsCliTest.php</file>
             <file>tests/CLIScaffoldingTest.php</file>
+            <file>tests/CommandsManifestTest.php</file>
             <file>tests/CsrfMiddlewareTest.php</file>
             <file>tests/GalleryTest.php</file>
             <file>tests/LiveReloadTest.php</file>

--- a/tests/CommandsManifestTest.php
+++ b/tests/CommandsManifestTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Real tests for the self-describing `commands` CLI subcommand (Phase 1 of the
+ * self-describing-client epic — the PHP mirror of the Python master).
+ *
+ * NO mocks. These exercise the ACTUAL CLI by shelling out to the real
+ * `bin/tina4php` entrypoint (exactly how the tina4 Rust client drives it) and
+ * parsing what it prints:
+ *
+ *   * content + shape of `commands --json` (framework/version/commands, args,
+ *     generate.subcommands);
+ *   * anti-drift lock-in — the manifest lists EXACTLY the commands the top-level
+ *     dispatch switch handles (the manifest is derived from the same
+ *     $TINA4_COMMANDS registry that gates dispatch, so they cannot diverge);
+ *   * app/DB-free — `commands --json` runs in an empty temp dir with NO database
+ *     configured, exits 0 with valid JSON, and creates no files / no database.
+ *     This is the contract the Rust client relies on when it calls the command
+ *     on every `tina4 --help`, in any directory.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CommandsManifestTest extends TestCase
+{
+    /** The command set the tina4 client must be able to discover truthfully. */
+    private const KNOWN_COMMANDS = [
+        'migrate', 'migrate:create', 'seed', 'test', 'routes', 'generate', 'commands',
+    ];
+
+    private static string $bin;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$bin = realpath(__DIR__ . '/../bin/tina4php');
+        self::assertNotFalse(self::$bin, 'bin/tina4php not found');
+    }
+
+    /**
+     * Run the REAL CLI entrypoint as a subprocess and return [stdout, stderr, exit].
+     * $cwd/$envOverride let a test prove the app/DB-free contract in a clean dir.
+     */
+    private function runCli(array $args, ?string $cwd = null, array $envOverride = []): array
+    {
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(self::$bin);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+
+        $env = $envOverride['__reset__'] ?? false ? [] : getenv();
+        unset($env['__reset__']);
+        foreach ($envOverride as $key => $value) {
+            if ($key === '__reset__') {
+                continue;
+            }
+            if ($value === null) {
+                unset($env[$key]);
+            } else {
+                $env[$key] = $value;
+            }
+        }
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open($cmd, $descriptors, $pipes, $cwd, $env);
+        self::assertIsResource($process, 'failed to start bin/tina4php');
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+
+        return [$stdout, $stderr, $exit];
+    }
+
+    /** The manifest emitted by the real `commands --json` subprocess. */
+    private function manifest(): array
+    {
+        [$stdout, $stderr, $exit] = $this->runCli(['commands', '--json']);
+        $this->assertSame(0, $exit, "commands --json exited non-zero; stderr:\n{$stderr}");
+        $manifest = json_decode($stdout, true);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), "commands --json is not valid JSON:\n{$stdout}");
+        return $manifest;
+    }
+
+    // ── Content ──────────────────────────────────────────────────────────
+
+    public function testFrameworkIsPhp(): void
+    {
+        $this->assertSame('php', $this->manifest()['framework']);
+    }
+
+    public function testVersionIsNonEmptyAndVersionish(): void
+    {
+        $version = $this->manifest()['version'];
+        $this->assertIsString($version);
+        $this->assertNotSame('', trim($version));
+        $this->assertMatchesRegularExpression('/^\d+\.\d+/', $version, "not version-looking: {$version}");
+    }
+
+    public function testCommandsAreNonEmptyAndWellFormed(): void
+    {
+        $commands = $this->manifest()['commands'];
+        $this->assertIsArray($commands);
+        $this->assertNotEmpty($commands);
+        foreach ($commands as $entry) {
+            $this->assertArrayHasKey('name', $entry);
+            $this->assertNotSame('', (string)$entry['name'], 'entry missing name: ' . json_encode($entry));
+            $this->assertArrayHasKey('summary', $entry);
+            $this->assertNotSame('', (string)$entry['summary'], 'entry missing summary: ' . json_encode($entry));
+        }
+    }
+
+    public function testKnownCommandsAllPresent(): void
+    {
+        $names = array_column($this->manifest()['commands'], 'name');
+        $missing = array_diff(self::KNOWN_COMMANDS, $names);
+        $this->assertSame([], array_values($missing), 'manifest missing commands: ' . implode(', ', $missing));
+    }
+
+    public function testGenerateHasSubcommandsWithModelAndCrud(): void
+    {
+        $commands = $this->manifest()['commands'];
+        $generate = null;
+        foreach ($commands as $entry) {
+            if ($entry['name'] === 'generate') {
+                $generate = $entry;
+                break;
+            }
+        }
+        $this->assertNotNull($generate, 'no generate command in manifest');
+        $this->assertArrayHasKey('subcommands', $generate);
+        $this->assertIsArray($generate['subcommands']);
+        $this->assertNotEmpty($generate['subcommands']);
+        $this->assertContains('model', $generate['subcommands']);
+        $this->assertContains('crud', $generate['subcommands']);
+    }
+
+    public function testMigrateCreateDeclaresItsPositionalArg(): void
+    {
+        $commands = $this->manifest()['commands'];
+        $entry = null;
+        foreach ($commands as $c) {
+            if ($c['name'] === 'migrate:create') {
+                $entry = $c;
+                break;
+            }
+        }
+        $this->assertNotNull($entry);
+        $this->assertSame(['description'], $entry['args'] ?? null);
+    }
+
+    public function testNoInventedTopLevelQueueCommand(): void
+    {
+        // `queue` exists only as a `generate` subcommand today — it must NOT
+        // masquerade as a top-level command (parity with the Python master).
+        $manifest = $this->manifest();
+        $names = array_column($manifest['commands'], 'name');
+        $this->assertNotContains('queue', $names);
+
+        $generate = null;
+        foreach ($manifest['commands'] as $c) {
+            if ($c['name'] === 'generate') {
+                $generate = $c;
+                break;
+            }
+        }
+        $this->assertContains('queue', $generate['subcommands'] ?? []);
+    }
+
+    // ── Anti-drift lock-in ───────────────────────────────────────────────
+
+    public function testManifestListsExactlyTheDispatchableCommands(): void
+    {
+        // The manifest is derived from the $TINA4_COMMANDS registry, which also
+        // GATES dispatch. This lock-in proves the top-level dispatch switch
+        // handles EXACTLY the commands the manifest advertises — add a `case`
+        // without registering it (or vice versa) and this test fails.
+        $source = file_get_contents(self::$bin);
+
+        // Top-level switch cases are indented exactly 4 spaces; the nested
+        // `generate` switch cases are indented 12, so they are excluded here.
+        preg_match_all("/^    case '([^']+)':/m", $source, $matches);
+        $dispatchable = $matches[1];
+
+        // Flag-style aliases are normalised to a real command before dispatch.
+        $dispatchable = array_values(array_diff($dispatchable, ['--help', '-h']));
+
+        $manifestNames = array_column($this->manifest()['commands'], 'name');
+
+        sort($dispatchable);
+        sort($manifestNames);
+        $this->assertSame(
+            $manifestNames,
+            $dispatchable,
+            'manifest command names drifted from the dispatch switch cases'
+        );
+    }
+
+    public function testUnknownCommandIsRejectedViaTheRegistry(): void
+    {
+        // A command absent from the registry is unknown — proves the registry
+        // (not a parallel list) is the gate for what the CLI will dispatch.
+        [$stdout, , $exit] = $this->runCli(['definitely-not-a-real-command']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Unknown command: definitely-not-a-real-command', $stdout);
+    }
+
+    // ── App/DB-free contract ─────────────────────────────────────────────
+
+    public function testCommandsJsonIsAppAndDbFree(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/tina4-cmdmanifest-' . getmypid() . '-' . uniqid();
+        mkdir($tempDir, 0755, true);
+
+        try {
+            $this->assertDirectoryDoesNotExist($tempDir . '/migrations');
+            $this->assertFileDoesNotExist($tempDir . '/app.php');
+
+            // Genuinely fresh: run in the empty dir with NO database configured.
+            [$stdout, $stderr, $exit] = $this->runCli(
+                ['commands', '--json'],
+                $tempDir,
+                ['TINA4_DATABASE_URL' => null, 'TINA4_AUTO_MIGRATE' => null]
+            );
+
+            $this->assertSame(0, $exit, "non-zero exit; stderr:\n{$stderr}");
+
+            $manifest = json_decode($stdout, true);
+            $this->assertSame(JSON_ERROR_NONE, json_last_error(), "not valid JSON:\n{$stdout}");
+            $this->assertSame('php', $manifest['framework']);
+            $this->assertNotSame('', trim((string)$manifest['version']));
+            $names = array_column($manifest['commands'], 'name');
+            $this->assertContains('commands', $names);
+            $this->assertContains('generate', $names);
+
+            // Nothing bootstrapped: no database file, nothing written to the dir.
+            $dbFiles = glob($tempDir . '/**/*.db') ?: [];
+            $dbFiles = array_merge($dbFiles, glob($tempDir . '/*.db') ?: []);
+            $this->assertSame([], $dbFiles, 'commands opened/created a database: ' . implode(', ', $dbFiles));
+
+            $entries = array_values(array_diff(scandir($tempDir), ['.', '..']));
+            $this->assertSame([], $entries, 'commands created files in the project dir: ' . implode(', ', $entries));
+        } finally {
+            @rmdir($tempDir);
+        }
+    }
+}


### PR DESCRIPTION
## Phase 1 MIRROR (PHP) of the self-describing CLI epic

Mirrors the Python master (tina4-python PR #79) into **tina4-php**. The `tina4php` CLI now emits its own command surface so the tina4 Rust client can DISCOVER what this framework supports instead of hardcoding it.

```
tina4php commands          human-readable list
tina4php commands --json   machine-readable manifest
```

### Single source of truth (kills three drifting copies)

`bin/tina4php` previously had three independent copies of the command surface: the dispatch `switch`, the hand-written help block, and the generators list. They are now derived from ONE registry each:

- `$TINA4_GENERATORS` -> the `generate` sub-list, the help text, AND the manifest's `generate.subcommands`
- `$TINA4_COMMANDS` -> the help text, the manifest, AND it now **gates dispatch** (an unknown command is one absent from the registry)

`tina4RenderHelp()` and `tina4CommandsManifest()` both read these registries, so help, discovery, and the dispatchable command set cannot drift.

### Refactor depth (honest scope)

This is the task's documented **fallback**, not the full closure-based dispatch rewrite. The 2618-line procedural `switch` has large case bodies that lean on shared top-level state (`$cwd`, `$FIELD_TYPE_MAP`, `$frameworkRoot`, ...), so extracting every case into a registry-held closure was judged too risky. Instead: the big `switch` **keeps its case bodies**, but the registry now **gates** it (unknown = not registered), and a **structural anti-drift lock-in test** asserts the switch's top-level `case` labels equal the manifest names — add a `case` without registering it (or vice versa) and the test fails.

### Manifest shape (identical to the Python master)

```json
{ "framework": "php", "version": "<resolved>",
  "commands": [ { "name": "...", "summary": "...", "args": ["..."]?, "subcommands": ["..."]? } ] }
```

Truthful to the real command set the PHP CLI dispatches (17 commands: init, serve, start, migrate, migrate:create, migrate:rollback, migrate:status, seed, routes, metrics, test, build, generate, ai, console, commands, help). `generate.subcommands` is derived live from `$TINA4_GENERATORS` (model, route, crud, migration, middleware, test, form, view, auth, service, queue, validator, seeder, websocket, listener).

### Cheap + side-effect-free by contract

The `commands` handler prints only the static registry + a **boot-free** version (read straight from `composer.json`/`installed.json`, mirroring `App::resolveVersion()` without loading the `App` class). It never bootstraps the app, opens a DB, runs migrations, or autoloads app classes — safe in any directory, which is what the Rust client relies on for `tina4 --help`.

### Real test (no mocks) — `tests/CommandsManifestTest.php`

Shells out to the REAL `bin/tina4php` entrypoint (exactly how the Rust client drives it):
- content + shape (framework=`php`, non-empty version, known commands present, `generate` subcommands incl. `model`/`crud`, `migrate:create` args)
- anti-drift lock-in: manifest names == the top-level dispatch switch cases
- app/DB-free: `commands --json` in an empty temp dir with no `TINA4_DATABASE_URL` -> exit 0, valid JSON, no file/database created

### Verification

- New test: **10/10 green** (124 assertions), macOS, PHP 8.5.7
- CLI-related suite (CLIScaffolding, CLIScaffoldingSecure, MetricsCli, CliMigrateExitCode, PortConfig, CommandsManifest): **96/96 green**
- Full suite: **2778 passed, 0 failed, 100 skipped** (unprovisioned services only), macOS, PHP 8.5.7 (SQLite). The 1 risky test + `setAccessible` deprecations are pre-existing in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)