### PR TITLE
ORM: add orderBy to where() (parity with find/all/QueryBuilder)

### DIFF
--- a/Tina4/ORM.php
+++ b/Tina4/ORM.php
@@ -1232,15 +1232,20 @@ abstract class ORM
      * @param array $params Bound parameters
      * @param int $limit Max results
      * @param int $offset Starting offset
+     * @param array|null $include Relationships to eager-load
+     * @param string|null $orderBy ORDER BY clause (e.g. "name ASC")
      * @return array<int, static>
      */
-    public function where(string $filterSql, array $params = [], int $limit = 20, int $offset = 0, ?array $include = null): array
+    public function where(string $filterSql, array $params = [], int $limit = 20, int $offset = 0, ?array $include = null, ?string $orderBy = null): array
     {
         $this->ensureDb();
 
         $sql = "SELECT * FROM {$this->tableName} WHERE {$filterSql}";
         if ($this->softDelete) {
             $sql = "SELECT * FROM {$this->tableName} WHERE ({$filterSql}) AND is_deleted = 0";
+        }
+        if ($orderBy !== null) {
+            $sql .= " ORDER BY {$orderBy}";
         }
 
         $result = $this->_db->fetch($sql, $params, $limit, $offset);

--- a/tests/OrmWhereOrderByTest.php
+++ b/tests/OrmWhereOrderByTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Lock-in tests for ORM::where(orderBy) — v3.13.66 ORM where-ordering parity.
+ *
+ * where() was the only filtered finder that could not order its results
+ * (find / all / QueryBuilder all could). These tests pin the new behaviour:
+ *   * orderBy sorts the filtered result (ASC and DESC)
+ *   * omitting orderBy injects NO ORDER BY (rows come back in natural order)
+ *
+ * Mirrors tina4-python/tests/test_orm_where_order_by.py (the Python master).
+ * Real in-memory SQLite (SQLite3Adapter), no mocks, positive + negative. Rows
+ * are inserted OUT OF alphabetical order so a missing/extra ORDER BY shows.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Database\SQLite3Adapter;
+use Tina4\ORM;
+
+class WhereOrderPerson extends ORM
+{
+    public string $tableName  = 'wpeople';
+    public string $primaryKey = 'id';
+    public bool   $autoMap    = true;
+
+    public ?int    $id   = null;
+    public ?string $name = null;
+}
+
+class OrmWhereOrderByTest extends TestCase
+{
+    private SQLite3Adapter $db;
+
+    protected function setUp(): void
+    {
+        $this->db = new SQLite3Adapter(':memory:');
+        $this->db->exec('CREATE TABLE wpeople (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        // Out of alphabetical order: Charlie(id=1), Alice(id=2), Bob(id=3)
+        $this->db->exec("INSERT INTO wpeople (name) VALUES ('Charlie')");
+        $this->db->exec("INSERT INTO wpeople (name) VALUES ('Alice')");
+        $this->db->exec("INSERT INTO wpeople (name) VALUES ('Bob')");
+        ORM::bindDatabase($this->db);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->db->close();
+    }
+
+    /** @param array<int, WhereOrderPerson> $rows @return array<int, string> */
+    private function names(array $rows): array
+    {
+        return array_map(static fn ($r) => $r->name, $rows);
+    }
+
+    public function testOrderByAscSortsResults(): void
+    {
+        $rows = (new WhereOrderPerson($this->db))->where('1=1', [], 20, 0, null, 'name ASC');
+        $this->assertSame(['Alice', 'Bob', 'Charlie'], $this->names($rows));
+    }
+
+    public function testOrderByDescReversesResults(): void
+    {
+        // id DESC -> 3, 2, 1 -> Bob, Alice, Charlie
+        $rows = (new WhereOrderPerson($this->db))->where('1=1', [], 20, 0, null, 'id DESC');
+        $this->assertSame(['Bob', 'Alice', 'Charlie'], $this->names($rows));
+    }
+
+    public function testWithoutOrderByIsUnchanged(): void
+    {
+        // negative: no orderBy -> no ORDER BY injected -> natural (insertion) order
+        $rows = (new WhereOrderPerson($this->db))->where('1=1');
+        $this->assertSame(['Charlie', 'Alice', 'Bob'], $this->names($rows));
+    }
+}


### PR DESCRIPTION
## What

`ORM::where()` was the only filtered finder that could not order its results — `find()`, `all()`, and `QueryBuilder` all can. This adds an optional `orderBy` param to `where()`.

## Change (`Tina4/ORM.php`)

- `where(...)` signature gains `?string $orderBy = null` as the **last** param (after `$include`) — backward-compatible.
- `ORDER BY {$orderBy}` is appended to the SELECT, matching the existing `all()` idiom.
- `orderBy` is interpolated as a column expression, matching the existing accepted convention in `find()`/`all()`/`QueryBuilder` (column expressions cannot be bound as params in any driver).

## Tests — `tests/OrmWhereOrderByTest.php` (real in-memory SQLite, no mocks, positive + negative)

- `orderBy 'name ASC'` sorts; `orderBy 'id DESC'` reverses (rows inserted out of order)
- omitting `orderBy` injects no ORDER BY (natural/insertion order preserved)

## Verification

- New test: 3 passed
- Full suite at HEAD: **2768 tests, 0 failures / 0 errors** (100 skipped; the 1 risky GalleryTest + deprecations are pre-existing, unrelated). PHP 8.5.7, macOS.

Mirrors the Python master (tina4-python#82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)