### PR TITLE
(HELD) feat(db): Firebird PDO fallback (pdo_firebird) — awaiting real-server verification

### DIFF
--- a/Tina4/Database/Database.php
+++ b/Tina4/Database/Database.php
@@ -1478,6 +1478,29 @@ class Database implements DatabaseAdapter
     }
 
     /**
+     * SILENT PDO fallback (Firebird): prefer ext-interbase (ibase_ / fbird_
+     * functions); fall back to the pdo_firebird driver when absent. This is the
+     * highest-value fallback — ext-interbase was removed from PHP core in 7.4
+     * (PECL-only, broken on macOS), so pdo_firebird is often the only Firebird
+     * driver present on a modern build.
+     *
+     * @throws \RuntimeException When neither ext-interbase nor pdo_firebird is present.
+     */
+    private static function makeFirebird(string $url, string $username, string $password, ?bool $autoCommit): DatabaseAdapter
+    {
+        if (function_exists('ibase_connect') || function_exists('fbird_connect')) {
+            return new FirebirdAdapter($url, username: $username, password: $password, autoCommit: $autoCommit);
+        }
+        if (in_array('firebird', \PDO::getAvailableDrivers(), true)) {
+            return new PdoFirebirdAdapter($url, username: $username, password: $password, autoCommit: $autoCommit);
+        }
+        throw new \RuntimeException(
+            'Firebird requires ext-interbase (ibase_*/fbird_* functions) or the pdo_firebird PDO driver. '
+            . 'ext-interbase was removed from PHP core in 7.4 (PECL-only); enable pdo_firebird instead.'
+        );
+    }
+
+    /**
      * Create the raw DatabaseAdapter from a connection URL string.
      *
      * @param string $url Connection URL
@@ -1550,11 +1573,11 @@ class Database implements DatabaseAdapter
             PostgresAdapter::class => self::makePostgres($url, $autoCommit, $username, $password),
             MySQLAdapter::class => new MySQLAdapter($url, username: $username, password: $password, autoCommit: $autoCommit),
             MSSQLAdapter::class => new MSSQLAdapter($url, username: $username, password: $password, autoCommit: $autoCommit),
-            FirebirdAdapter::class => new FirebirdAdapter(
+            FirebirdAdapter::class => self::makeFirebird(
                 $url,
-                username: $username !== '' ? $username : (isset($parts['user']) ? urldecode($parts['user']) : 'SYSDBA'),
-                password: $password !== '' ? $password : (isset($parts['pass']) ? urldecode($parts['pass']) : 'masterkey'),
-                autoCommit: $autoCommit,
+                $username !== '' ? $username : (isset($parts['user']) ? urldecode($parts['user']) : 'SYSDBA'),
+                $password !== '' ? $password : (isset($parts['pass']) ? urldecode($parts['pass']) : 'masterkey'),
+                $autoCommit,
             ),
             MongoDBAdapter::class => new MongoDBAdapter(
                 $url,

--- a/Tina4/Database/PdoFirebirdAdapter.php
+++ b/Tina4/Database/PdoFirebirdAdapter.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Database;
+
+/**
+ * Firebird database adapter over the pdo_firebird driver — the SILENT fallback
+ * used by Database::create() when ext-interbase (ibase_ / fbird_ functions) is
+ * absent.
+ *
+ * This is the highest-value fallback: ext-interbase was removed from PHP core
+ * in 7.4 (PECL-only, broken on macOS), so FirebirdAdapter throws on most modern
+ * builds. pdo_firebird ships with mainstream PHP distributions.
+ *
+ * Externally mirrors FirebirdAdapter: trims CHAR padding, reads BLOBs into raw
+ * byte strings, uses ROWS X TO Y pagination, appends RETURNING * on insert
+ * (falling back to a plain INSERT), and preserves the fail-loud contract.
+ */
+class PdoFirebirdAdapter implements DatabaseAdapter
+{
+    use SqlNormalizerTrait;
+    use PdoAdapterTrait;
+
+    public function __construct(
+        private readonly string $connectionString,
+        private readonly string $username = 'SYSDBA',
+        private readonly string $password = 'masterkey',
+        private readonly string $charset = 'UTF8',
+        ?bool $autoCommit = null,
+    ) {
+        $this->autoCommit = $this->resolveAutoCommit($autoCommit);
+        $this->open();
+    }
+
+    protected function engineLabel(): string
+    {
+        return 'Firebird (PDO)';
+    }
+
+    protected function buildDsn(): array
+    {
+        $params = $this->parseConnection($this->connectionString);
+
+        $dbPath = $params['database'];
+        if ($params['host'] !== '') {
+            $dbPath = $params['host'];
+            if ($params['port'] > 0 && $params['port'] !== 3050) {
+                $dbPath .= '/' . $params['port'];
+            }
+            $dbPath .= ':' . $params['database'];
+        }
+
+        $dsn = "firebird:dbname={$dbPath};charset={$this->charset}";
+        return [$dsn, $params['username'], $params['password'], []];
+    }
+
+    /** Firebird has no native BOOLEAN below 3.0 — bind booleans as 1/0. */
+    protected function normalizeParams(array $params): array
+    {
+        return self::normalizeBoolParams($params, nativeBoolean: false);
+    }
+
+    protected function paginate(string $sql, int $limit, int $offset): string
+    {
+        $startRow = $offset + 1;
+        $endRow = $offset + $limit;
+        return "{$sql} ROWS {$startRow} TO {$endRow}";
+    }
+
+    protected function insertReturningClause(): string
+    {
+        return ' RETURNING *';
+    }
+
+    /** Firebird pads/returns identifiers with trailing spaces — trim like native. */
+    protected function normalizeReturnedId(mixed $value): int|string
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * Trim CHAR padding from strings and read BLOB streams into raw byte
+     * strings — matching FirebirdAdapter::query()'s cleaning loop.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @param array<int, array<string, mixed>> $meta
+     */
+    protected function coerceRows(array $rows, array $meta): array
+    {
+        foreach ($rows as &$row) {
+            foreach ($row as $key => $value) {
+                if (is_resource($value)) {
+                    $row[$key] = stream_get_contents($value);
+                } elseif (is_string($value)) {
+                    $row[$key] = rtrim($value);
+                }
+            }
+        }
+        unset($row);
+        return $rows;
+    }
+
+    public function getDatabase(): string
+    {
+        return $this->connectionString;
+    }
+
+    public function tableExists(string $table): bool
+    {
+        $rows = $this->query(
+            "SELECT RDB\$RELATION_NAME FROM RDB\$RELATIONS WHERE RDB\$SYSTEM_FLAG = 0 AND RDB\$VIEW_BLR IS NULL AND TRIM(RDB\$RELATION_NAME) = ?",
+            [strtoupper($table)]
+        );
+        return count($rows) > 0;
+    }
+
+    public function getColumns(string $table): array
+    {
+        $sql = "SELECT RF.RDB\$FIELD_NAME AS field_name,
+                       F.RDB\$FIELD_TYPE AS field_type,
+                       RF.RDB\$NULL_FLAG AS null_flag,
+                       RF.RDB\$DEFAULT_SOURCE AS default_source
+                FROM RDB\$RELATION_FIELDS RF
+                JOIN RDB\$FIELDS F ON RF.RDB\$FIELD_SOURCE = F.RDB\$FIELD_NAME
+                WHERE RF.RDB\$RELATION_NAME = ?
+                ORDER BY RF.RDB\$FIELD_POSITION";
+
+        $rows = $this->query($sql, [strtoupper($table)]);
+
+        $typeMap = [
+            7 => 'SMALLINT', 8 => 'INTEGER', 10 => 'FLOAT', 12 => 'DATE',
+            13 => 'TIME', 14 => 'CHAR', 16 => 'BIGINT', 27 => 'DOUBLE PRECISION',
+            35 => 'TIMESTAMP', 37 => 'VARCHAR', 261 => 'BLOB',
+        ];
+
+        $pkRows = $this->query(
+            "SELECT TRIM(ISG.RDB\$FIELD_NAME) AS pk_field
+             FROM RDB\$RELATION_CONSTRAINTS RC
+             JOIN RDB\$INDEX_SEGMENTS ISG ON RC.RDB\$INDEX_NAME = ISG.RDB\$INDEX_NAME
+             WHERE RC.RDB\$CONSTRAINT_TYPE = 'PRIMARY KEY' AND RC.RDB\$RELATION_NAME = ?",
+            [strtoupper($table)]
+        );
+        $pkFields = array_map('trim', array_column($pkRows, 'PK_FIELD'));
+
+        $columns = [];
+        foreach ($rows as $row) {
+            $fieldName = trim($row['FIELD_NAME'] ?? $row['field_name'] ?? '');
+            $fieldType = (int) ($row['FIELD_TYPE'] ?? $row['field_type'] ?? 0);
+            $columns[] = [
+                'name' => $fieldName,
+                'type' => $typeMap[$fieldType] ?? "TYPE_{$fieldType}",
+                'nullable' => ($row['NULL_FLAG'] ?? $row['null_flag'] ?? null) === null,
+                'default' => $row['DEFAULT_SOURCE'] ?? $row['default_source'] ?? null,
+                'primary' => in_array($fieldName, $pkFields, true),
+            ];
+        }
+        return $columns;
+    }
+
+    public function getTables(): array
+    {
+        $rows = $this->query(
+            "SELECT TRIM(RDB\$RELATION_NAME) AS table_name FROM RDB\$RELATIONS WHERE RDB\$SYSTEM_FLAG = 0 AND RDB\$VIEW_BLR IS NULL ORDER BY RDB\$RELATION_NAME"
+        );
+        return array_map(
+            static fn($row) => trim($row['TABLE_NAME'] ?? $row['table_name'] ?? ''),
+            $rows
+        );
+    }
+
+    /**
+     * Parse a connection string (URL or path) into connection params — same
+     * rules as FirebirdAdapter (TINA4_DATABASE_FIREBIRD_PATH override, then
+     * FirebirdAdapter::normalizeDbIdentifier on the URL path).
+     *
+     * @return array{host: string, port: int, username: string, password: string, database: string}
+     */
+    private function parseConnection(string $input): array
+    {
+        $envOverride = \Tina4\DotEnv::getEnv('TINA4_DATABASE_FIREBIRD_PATH');
+
+        if (str_contains($input, '://')) {
+            $parts = parse_url($input);
+            $rawPath = $parts['path'] ?? '';
+            $database = ($envOverride !== null && $envOverride !== '')
+                ? $envOverride
+                : FirebirdAdapter::normalizeDbIdentifier($rawPath);
+            return [
+                'host' => $parts['host'] ?? '',
+                'port' => $parts['port'] ?? 3050,
+                'username' => isset($parts['user']) ? urldecode($parts['user']) : $this->username,
+                'password' => isset($parts['pass']) ? urldecode($parts['pass']) : $this->password,
+                'database' => $database,
+            ];
+        }
+
+        return [
+            'host' => '',
+            'port' => 3050,
+            'username' => $this->username,
+            'password' => $this->password,
+            'database' => ($envOverride !== null && $envOverride !== '') ? $envOverride : $input,
+        ];
+    }
+}

--- a/plan/pdo-silent-fallback.md
+++ b/plan/pdo-silent-fallback.md
@@ -73,20 +73,9 @@ MySQL/MSSQL/ODBC already use PDO/mysqli — left untouched.
 - Factory native-absent decision proven for real via a no-extension subprocess
   (php -n unloads ext-interbase; no pdo_firebird) -> combined error raised.
 
-## UNVERIFIED / HELD
+## UNVERIFIED
 - Firebird PDO fallback live run: this PHP build has NO pdo_firebird driver
-  compiled in, so the Firebird parity test could not run live. Code + test are
-  written but HELD.
+  compiled in, so the Firebird parity test SKIPS (loudly). Code + test written;
+  live run against a real Firebird + pdo_firebird still owed.
 
-## Split decision (owner ruling 2026-07-10)
-Ship the two engines that are verified live, hold the one that is not.
-- **3.13.66 (feature/php-pdo-sqlite-pg -> v3):** SQLite + PostgreSQL PDO
-  fallback (PdoAdapterTrait, PdoSqliteAdapter, PdoPostgresAdapter, the
-  makeSqlite/makePostgres factory selectors) + their parity/factory tests.
-- **Held (feature/php-pdo-fallback):** PdoFirebirdAdapter, the makeFirebird
-  selector, the Firebird parity cases, and the no-driver combined-error factory
-  test. Merges once pdo_firebird can be exercised against a real Firebird server
-  (the combined-error test needs ext-interbase, the only shared DB extension a
-  `php -n` subprocess can unload).
-
-## Status: SPLIT — SQLite + PostgreSQL shipping in 3.13.66 (verified live); Firebird held until pdo_firebird can be verified against a real server
+## Status: DONE — SQLite + PostgreSQL verified live; Firebird implemented, live UNVERIFIED

--- a/tests/PdoFallbackFactoryTest.php
+++ b/tests/PdoFallbackFactoryTest.php
@@ -95,9 +95,52 @@ class PdoFallbackFactoryTest extends TestCase
         $adapter->close();
     }
 
-    // NOTE: the "neither native nor PDO -> combined error" factory test lives
-    // with the held Firebird work on feature/php-pdo-fallback. It relied on the
-    // Firebird path because ext-interbase is the only shared DB extension a
-    // `php -n` subprocess can unload (ext-sqlite3 / ext-pgsql are statically
-    // compiled). It returns to CI once pdo_firebird can be verified live.
+    /**
+     * When BOTH the native extension AND the PDO driver are absent for an
+     * engine, the factory raises a clear combined error naming both options.
+     * Exercised for real in a no-extension subprocess (php -n unloads the
+     * shared ext-interbase); portable — asserts only when the subprocess env
+     * genuinely has neither Firebird driver.
+     */
+    public function testFactoryRaisesCombinedErrorWhenNoFirebirdDriver(): void
+    {
+        $autoload = dirname(__DIR__) . '/vendor/autoload.php';
+        $script = <<<'PHP'
+require %s;
+$avail = [
+    'ibase'   => function_exists('ibase_connect'),
+    'fbird'   => function_exists('fbird_connect'),
+    'pdo_fb'  => in_array('firebird', PDO::getAvailableDrivers(), true),
+];
+try {
+    \Tina4\Database\Database::create('firebird://SYSDBA:masterkey@localhost:3050/test.fdb');
+    $avail['result'] = 'no-error';
+    $avail['msg'] = '';
+} catch (\RuntimeException $e) {
+    $avail['result'] = 'runtime-exception';
+    $avail['msg'] = $e->getMessage();
+} catch (\Throwable $e) {
+    $avail['result'] = 'other:' . get_class($e);
+    $avail['msg'] = $e->getMessage();
+}
+echo json_encode($avail);
+PHP;
+        $script = sprintf($script, var_export($autoload, true));
+        $cmd = escapeshellarg(PHP_BINARY) . ' -n -r ' . escapeshellarg($script);
+        $out = shell_exec($cmd);
+        $this->assertNotNull($out, 'subprocess produced no output');
+        $data = json_decode(trim($out), true);
+        $this->assertIsArray($data, "subprocess output was not JSON: {$out}");
+
+        if ($data['ibase'] || $data['fbird'] || $data['pdo_fb']) {
+            $this->markTestSkipped(
+                'Subprocess still has a Firebird driver — cannot exercise the no-driver error path here.'
+            );
+        }
+
+        // Neither native ext-interbase nor pdo_firebird -> combined error.
+        $this->assertSame('runtime-exception', $data['result'], "unexpected result: {$out}");
+        $this->assertStringContainsString('Firebird requires', $data['msg']);
+        $this->assertStringContainsString('pdo_firebird', $data['msg']);
+    }
 }

--- a/tests/PdoFallbackParityTest.php
+++ b/tests/PdoFallbackParityTest.php
@@ -8,11 +8,9 @@
  * SILENT PDO fallback — native-vs-PDO PARITY lock-in.
  *
  * For each engine that hard-depends on a native extension (SQLite/ext-sqlite3,
- * PostgreSQL/ext-pgsql), Database::create() silently falls back to the matching
- * PDO driver when the native extension is absent. The fallback MUST be
- * externally indistinguishable from the native adapter. (Firebird's PDO
- * fallback is held on feature/php-pdo-fallback until pdo_firebird can be
- * verified against a real server — see the note near the Firebird section.)
+ * PostgreSQL/ext-pgsql, Firebird/ext-interbase), Database::create() silently
+ * falls back to the matching PDO driver when the native extension is absent.
+ * The fallback MUST be externally indistinguishable from the native adapter.
  *
  * This test runs the SAME assertions through BOTH the native driver AND the
  * forced-PDO driver against the SAME real database and asserts IDENTICAL
@@ -37,6 +35,8 @@ use Tina4\Database\SQLite3Adapter;
 use Tina4\Database\PdoSqliteAdapter;
 use Tina4\Database\PostgresAdapter;
 use Tina4\Database\PdoPostgresAdapter;
+use Tina4\Database\FirebirdAdapter;
+use Tina4\Database\PdoFirebirdAdapter;
 
 class PdoFallbackParityTest extends TestCase
 {
@@ -272,10 +272,73 @@ class PdoFallbackParityTest extends TestCase
         $pdo->close();
     }
 
-    // NOTE: Firebird PDO fallback (PdoFirebirdAdapter + Database::makeFirebird)
-    // is held on feature/php-pdo-fallback until it can run against a real
-    // Firebird server (pdo_firebird is absent locally and in CI). SQLite +
-    // PostgreSQL ship in 3.13.66; Firebird follows once verified live.
+    // ─────────────────────────────────────────────────────────────────
+    // Firebird — ext-interbase vs pdo_firebird (real server required)
+    // ─────────────────────────────────────────────────────────────────
+
+    private function firebirdPair(): array
+    {
+        if (!in_array('firebird', \PDO::getAvailableDrivers(), true)) {
+            $this->markTestSkipped(
+                'pdo_firebird driver is not available — Firebird PDO fallback is UNVERIFIED in this environment.'
+            );
+        }
+        $url = getenv('TINA4_TEST_FIREBIRD_URL');
+        if ($url === false || $url === '') {
+            $this->markTestSkipped(
+                'TINA4_TEST_FIREBIRD_URL not set (needs a real Firebird server) — Firebird PDO fallback UNVERIFIED.'
+            );
+        }
+        $native = function_exists('ibase_connect') || function_exists('fbird_connect')
+            ? new FirebirdAdapter($url)
+            : null;
+        if ($native === null) {
+            $this->markTestSkipped('ext-interbase not available to compare against — Firebird parity UNVERIFIED.');
+        }
+        return [$native, new PdoFirebirdAdapter($url)];
+    }
+
+    public function testFirebirdTypedReadAndBlobParity(): void
+    {
+        [$native, $pdo] = $this->firebirdPair();
+        // Firebird uses generators, not AUTOINCREMENT; ROWS pagination; BLOB SUB_TYPE.
+        try {
+            $native->execute('DROP TABLE T4_PDO_PARITY');
+        } catch (\Throwable) {
+            // table may not exist yet — fine
+        }
+        $native->execute(
+            'CREATE TABLE T4_PDO_PARITY (ID INTEGER NOT NULL PRIMARY KEY, QTY INTEGER, '
+            . 'PRICE DOUBLE PRECISION, NAME VARCHAR(50), DATA BLOB SUB_TYPE 0)'
+        );
+        $native->execute(
+            'INSERT INTO T4_PDO_PARITY (ID, QTY, PRICE, NAME, DATA) VALUES (?, ?, ?, ?, ?)',
+            [1, 42, 19.99, 'widget', self::BLOB]
+        );
+
+        $sql = 'SELECT QTY, PRICE, NAME, DATA FROM T4_PDO_PARITY WHERE ID = 1';
+        $nativeRow = $native->fetchOne($sql);
+        $pdoRow = $pdo->fetchOne($sql);
+
+        $this->assertSame($nativeRow, $pdoRow, 'Firebird native vs PDO row must be byte- and type-identical');
+        $this->assertSame(self::BLOB, $pdoRow['DATA'] ?? $pdoRow['data'] ?? null);
+
+        try {
+            $native->execute('DROP TABLE T4_PDO_PARITY');
+        } catch (\Throwable) {
+        }
+        $native->close();
+        $pdo->close();
+    }
+
+    public function testFirebirdExecuteRaisesParity(): void
+    {
+        [$native, $pdo] = $this->firebirdPair();
+        $this->assertExecuteRaises($native, 'INSERT INTO T4_PDO_NOPE_MISSING (X) VALUES (1)');
+        $this->assertExecuteRaises($pdo, 'INSERT INTO T4_PDO_NOPE_MISSING (X) VALUES (1)');
+        $native->close();
+        $pdo->close();
+    }
 
     // ─────────────────────────────────────────────────────────────────
     // Shared exercisers (run identically against native and PDO)


### PR DESCRIPTION
**HELD** (owner ruling 2026-07-10). The SQLite + PostgreSQL PDO fallback shipped separately via #154 (verified live and merged to v3). This branch retains the **Firebird** piece:

- `PdoFirebirdAdapter`
- `Database::makeFirebird` (native ext-interbase -> pdo_firebird fallback)
- the Firebird parity cases in `PdoFallbackParityTest`
- the no-driver combined-error factory test (needs `php -n` unloading the shared ext-interbase)

**Why held:** `pdo_firebird` is not compiled into the local PHP build or CI, so the Firebird fallback has never run live. Per the no-mock rule, it does not ship unverified.

**To resume:** rebase this branch onto current `v3` (the SQLite+PG hunks drop out as already-present), stand up a real Firebird server + a PHP with `pdo_firebird`, set `TINA4_TEST_FIREBIRD_URL`, and confirm the Firebird parity + combined-error tests green. Then re-open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)