### PR TITLE
docs(claude): sync where() stub with the order_by signature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ $user->findById($id): self
 $user->find($filter, $limit, $offset, $orderBy): array
 $user->select($sql, $params, $limit, $offset): array
 $user->selectOne($sql, $params, $include): ?static
-$user->where($filterSql, $params, $limit, $offset): array
+$user->where($filterSql, $params, $limit, $offset, $include, $orderBy): array
 $user->all($limit, $offset): array
 $user->count($conditions, $params): int
 $user->findOrFail($id): static


### PR DESCRIPTION
The `where(order_by)` parity feature landed the params in code, but the `CLAUDE.md` `Model.where()` stub still showed the old signature. This syncs the stub to the real source signature (verified against the ORM source on v3) so the framework's own AI docs match code reality. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)