### PR TITLE
docs(skill): add "check for Tina4 updates" to the developer skill(s)

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -535,6 +535,21 @@ Target modern PHP. The framework requires **PHP 8.2+**; use the latest stable re
 Use modern language features — readonly properties, enums, named arguments, first-class callable
 syntax, constructor promotion, `match`. Never write code that targets older versions.
 
+## Staying current: check for Tina4 updates
+
+Tina4 ships fixes and features often, and a bug the user reports may already be fixed
+upstream. When you start substantial work — or whenever a user hits a bug a newer release
+might resolve — check whether the project's Tina4 is behind the latest, then surface it.
+**Never upgrade silently:** report the delta and let the user decide (a version bump can
+change behaviour).
+
+- **Installed vs latest:** `composer outdated tina4stack/tina4php` (the Composer package id
+  is `tina4stack/tina4php` — no hyphen — not the repo name). The `tina4` CLI's own version:
+  `tina4 --version`.
+- **If behind:** tell the user what changed — point them at the release notes on
+  https://tina4.com — and offer the upgrade: `composer update tina4stack/tina4php`.
+- The `tina4` CLI self-updates with `tina4 update`; `tina4 doctor` checks your toolchain.
+
 ## Reference Files
 
 Read these when you need detailed patterns for a specific area:


### PR DESCRIPTION
Adds a concise **Staying current: check for Tina4 updates** section to the app-developer skill: the AI checks whether the project's installed Tina4 is behind the latest release (framework-specific `outdated`/version check) and surfaces the delta with the upgrade command — **never upgrading silently**. tina4-python also carries the shared **tina4-js** skill's equivalent section (`npm outdated tina4js` + the vendored-bundle note).

Skill docs only. Commands referenced (`tina4 update`, `tina4 doctor`, `composer/npm/gem/pip outdated`) are real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)