### PR TITLE
feat(cli): Phase 3 mirror — queue command + build (mirror Python master)

### DIFF
--- a/bin/tina4php
+++ b/bin/tina4php
@@ -15,7 +15,8 @@
  *   tina4php routes                 List all registered routes
  *   tina4php metrics [opts]         Rank top code-quality offenders (--top N, --json, --fail-on, --path)
  *   tina4php test                   Run test suite
- *   tina4php build                  Build distributable package
+ *   tina4php queue <work|stats|retry|clear> [topic]  Run queue workers and manage jobs
+ *   tina4php build [--tag N] [--file P]  Build the deployable Docker image
  *   tina4php generate <what> <name>  Generate scaffolding
  *   tina4php ai [--all]             Detect AI tools and install context
  *   tina4php console                Drop into an interactive PHP REPL with Tina4 loaded
@@ -246,7 +247,7 @@ function parseFlags(array $args): array
 {
     // Boolean-only flags that never take a value argument
     $booleanFlags = ['no-browser', 'no-reload', 'production', 'managed', 'all', 'clear', 'json',
-                     'public', 'no-migration'];
+                     'public', 'no-migration', 'once'];
 
     $flags = [];
     $positional = [];
@@ -488,6 +489,11 @@ function tina4RenderCommands(array $manifest): string
     return implode("\n", $lines) . "\n";
 }
 
+// Sub-dispatch table for the top-level `queue` command — the single source for
+// its subcommands (drives tina4Queue() dispatch AND the manifest's
+// queue.subcommands). Mirrors the Python master's _QUEUE_SUBCOMMANDS.
+$TINA4_QUEUE_SUBCOMMANDS = ['work', 'stats', 'retry', 'clear'];
+
 $TINA4_GENERATORS = [
     'model'      => ['usage' => '<Name> [--fields "name:string,price:float"]', 'summary' => 'ORM model + matching migration'],
     'route'      => ['usage' => '<name> [--model Name] [--public]',            'summary' => 'CRUD route file, secure by default (--public opens writes)'],
@@ -518,7 +524,8 @@ $TINA4_COMMANDS = [
     'routes'           => [                                                          'summary' => 'List all registered routes'],
     'metrics'          => ['usage' => '[--top N] [--json] [--fail-on warn|error] [--path DIR]', 'summary' => 'Rank top code-quality offenders'],
     'test'             => [                                                          'summary' => 'Run test suite'],
-    'build'            => [                                                          'summary' => 'Build distributable package'],
+    'queue'            => ['usage' => '<work|stats|retry|clear> [topic]', 'subcommands' => $TINA4_QUEUE_SUBCOMMANDS, 'summary' => 'Run queue workers and manage jobs'],
+    'build'            => ['usage' => '[--tag NAME] [--file PATH]',                   'summary' => 'Build the deployable Docker image'],
     'generate'         => ['usage' => '<what> <name> [options]', 'subcommands' => array_keys($TINA4_GENERATORS), 'summary' => 'Generate scaffolding (see Generators below)'],
     'ai'               => ['usage' => '[--all]',                                     'summary' => 'Detect AI tools and install context'],
     'console'          => [                                                          'summary' => 'Interactive PHP REPL with Tina4 loaded'],
@@ -1149,10 +1156,19 @@ DOCKERFILE;
         break;
 
     // ────────────────────────────────────────────
-    // BUILD — Build distributable
+    // QUEUE — Run workers and manage jobs (top-level; distinct from `generate
+    // queue`, which SCAFFOLDS a consumer). Wires straight to the real
+    // \Tina4\Queue — no app/DB boot needed.
+    // ────────────────────────────────────────────
+    case 'queue':
+        tina4Queue($args, $TINA4_QUEUE_SUBCOMMANDS);
+        break;
+
+    // ────────────────────────────────────────────
+    // BUILD — Build the deployable Docker image
     // ────────────────────────────────────────────
     case 'build':
-        echo "Build not yet implemented in v3.\n";
+        tina4Build($args);
         break;
 
     // ────────────────────────────────────────────
@@ -2541,10 +2557,11 @@ function generateQueue(string $name, array $flags): void
 
 return [
     'name'    => '{$topic}-consumer',
+    'topic'   => '{$topic}',  // lets `tina4php queue work {$topic}` drive this consumer
     'handler' => \$consume,
     'daemon'  => true,
     'publish' => \$publish,   // extra keys ignored by discover(); handy for producers
-    'handle'  => \$handle,    // exposed for testing / direct dispatch
+    'handle'  => \$handle,    // per-job handler `queue work` calls (own poll loop / --once)
 ];
 
 PHP;
@@ -2787,4 +2804,357 @@ return \$listener;
 PHP;
     file_put_contents($path, $content);
     echo "  Created {$path}\n";
+}
+
+
+// ════════════════════════════════════════════════════════════════════════
+// Queue command (top-level) — run workers and manage jobs
+// ════════════════════════════════════════════════════════════════════════
+//
+// Wires straight to the real \Tina4\Queue (file backend by default; RabbitMQ /
+// Kafka / MongoDB via TINA4_QUEUE_BACKEND). `stats`, `retry` and `clear` operate
+// on the queue without booting the app or a database; `work` runs the app's
+// consumer for a topic. Distinct from `generate queue`, which SCAFFOLDS a
+// consumer file. Mirrors the Python master's _queue* handlers (external
+// behaviour: subcommand names, flags, output shape, exit codes).
+
+/**
+ * Break out of a long-running `queue work` poll loop on Ctrl-C. Thrown from the
+ * SIGINT handler (async signals) so it interrupts the poll sleep immediately —
+ * the parity analogue of Python's KeyboardInterrupt propagating out of consume().
+ */
+final class Tina4QueueWorkerInterrupt extends \RuntimeException
+{
+}
+
+/**
+ * Locate an executable on PATH — a stdlib-only `which`, mirroring Python's
+ * shutil.which(). Honours the process PATH env, so a caller with an emptied PATH
+ * genuinely finds nothing. Returns the full path, or null when absent.
+ */
+function tina4Which(string $name): ?string
+{
+    $path = getenv('PATH');
+    if ($path === false || $path === '') {
+        return null;
+    }
+    $exts = [''];
+    if (PHP_OS_FAMILY === 'Windows') {
+        $pathext = getenv('PATHEXT') ?: '.EXE;.CMD;.BAT;.COM';
+        $exts = array_merge([''], explode(';', $pathext));
+    }
+    foreach (explode(PATH_SEPARATOR, $path) as $dir) {
+        if ($dir === '') {
+            continue;
+        }
+        foreach ($exts as $ext) {
+            $candidate = rtrim($dir, '/\\') . DIRECTORY_SEPARATOR . $name . $ext;
+            if (is_file($candidate) && is_executable($candidate)) {
+                return $candidate;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Return the per-job handler a consumer module declares for $topic.
+ *
+ * A consumer file (e.g. the one `generate queue <topic>` scaffolds) `return`s an
+ * array exposing a 'topic' and a per-job 'handle' callable. When its topic
+ * matches, `queue work` drives that consumer through the handle — so the worker
+ * owns the poll loop (honouring --poll and the bounded --once drain) instead of
+ * the consumer's own endless loop. Returns the callable, or null when no
+ * consumer in $servicesDir targets this topic. Mirrors Python's
+ * _resolve_queue_handler.
+ */
+function tina4ResolveQueueHandler(string $servicesDir, string $topic): ?callable
+{
+    if (!is_dir($servicesDir)) {
+        return null;
+    }
+    $files = glob(rtrim($servicesDir, '/\\') . '/*.php') ?: [];
+    sort($files);
+    foreach ($files as $file) {
+        if (str_starts_with(basename($file), '_')) {
+            continue;
+        }
+        try {
+            // require (not _once) so a re-scan re-reads the returned array; a
+            // broken sibling must not sink the worker.
+            $config = require $file;
+        } catch (\Throwable) {
+            continue;
+        }
+        if (is_array($config)
+            && ($config['topic'] ?? null) === $topic
+            && isset($config['handle']) && is_callable($config['handle'])) {
+            return $config['handle'];
+        }
+    }
+    return null;
+}
+
+/**
+ * queue work — run a consumer loop that pops and processes jobs on a topic.
+ *
+ *   tina4php queue work [topic] [--once] [--poll N] [--services DIR]
+ *
+ * Long-running by default (polls every --poll seconds, 1.0 default; Ctrl-C to
+ * stop). --once does a single-pass drain — processes every currently available
+ * job then exits (poll interval 0). The per-job handler is resolved from the
+ * app's consumer for this topic; with no handler it drains and acks with a
+ * warning rather than inventing behaviour.
+ */
+function tina4QueueWork(array $args): void
+{
+    [$flags, $positional] = parseFlags($args);
+    $topic = $positional[0] ?? 'default';
+    $once = !empty($flags['once']);
+
+    $pollValue = $flags['poll'] ?? null;
+    $poll = is_numeric($pollValue) ? (float)$pollValue : ($once ? 0.0 : 1.0);
+    if ($once) {
+        $poll = 0.0; // single-pass: consume() returns as soon as the topic is empty
+    }
+
+    $servicesDir = $flags['services'] ?? (getenv('TINA4_SERVICE_DIR') ?: 'src/services');
+    if ($servicesDir === true) {
+        $servicesDir = 'src/services';
+    }
+
+    $handler = tina4ResolveQueueHandler((string)$servicesDir, $topic);
+    $queue = new \Tina4\Queue(topic: $topic);
+
+    if ($handler === null) {
+        echo "  ⚠ No consumer handler found for topic '{$topic}' in {$servicesDir}.\n";
+        echo "    Scaffold one with: tina4php generate queue {$topic}\n";
+        echo "    Draining (consume + ack) without processing.\n";
+    }
+
+    $mode = $once ? 'single-pass drain' : ('polling every ' . sprintf('%g', $poll) . 's (Ctrl-C to stop)');
+    echo "  Queue worker on '{$topic}' — {$mode}...\n";
+
+    // Ctrl-C parity with Python's KeyboardInterrupt: with pcntl available the
+    // SIGINT handler throws, breaking out of the poll sleep at once. Without
+    // pcntl the default signal terminates the process (only the tidy
+    // "Interrupted" line is missed) — never needed for the bounded --once drain.
+    if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
+        pcntl_async_signals(true);
+        pcntl_signal(SIGINT, static function (): void {
+            throw new Tina4QueueWorkerInterrupt();
+        });
+    }
+
+    $processed = 0;
+    $failed = 0;
+    try {
+        foreach ($queue->consume($topic, null, $poll) as $job) {
+            try {
+                if ($handler !== null) {
+                    $handler($job->payload);
+                }
+                $job->complete();          // ack — job done, remove from the queue
+                $processed++;
+            } catch (Tina4QueueWorkerInterrupt $interrupt) {
+                throw $interrupt;          // Ctrl-C mid-job — let the worker stop
+            } catch (\Throwable $error) {
+                $job->fail($error->getMessage()); // nack — retry / dead-letter
+                $failed++;
+            }
+        }
+    } catch (Tina4QueueWorkerInterrupt) {
+        echo "\n  Interrupted — stopping worker.\n";
+    }
+
+    echo "  Processed {$processed} job(s), {$failed} failed on '{$topic}'.\n";
+}
+
+/**
+ * queue stats — print pending / in-flight / failed / dead-letter / completed
+ * counts for a topic.
+ *
+ *   tina4php queue stats [topic] [--json]
+ */
+function tina4QueueStats(array $args): void
+{
+    [$flags, $positional] = parseFlags($args);
+    $topic = $positional[0] ?? 'default';
+
+    $queue = new \Tina4\Queue(topic: $topic);
+    $stats = [
+        'topic'     => $topic,
+        'pending'   => $queue->size('pending'),   // waiting to run
+        'reserved'  => $queue->size('reserved'),  // popped, not yet acked (in-flight)
+        'failed'    => count($queue->failed()),   // failed once, still retrying
+        'dead'      => $queue->size('dead'),      // exhausted retries (dead-letter)
+        'completed' => $queue->size('completed'), // terminal-completed (0 on file backend)
+    ];
+
+    if (!empty($flags['json'])) {
+        echo json_encode($stats, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
+        return;
+    }
+
+    echo "\n  Queue '{$topic}'\n";
+    echo "    pending    {$stats['pending']}\n";
+    echo "    reserved   {$stats['reserved']}    (in-flight)\n";
+    echo "    failed     {$stats['failed']}    (retrying)\n";
+    echo "    dead       {$stats['dead']}    (dead-letter)\n";
+    echo "    completed  {$stats['completed']}\n";
+    echo "\n";
+}
+
+/**
+ * queue retry — re-queue failed and dead-letter jobs so they run again.
+ *
+ *   tina4php queue retry [topic]
+ *
+ * Revives every dead-letter job (manual override, regardless of attempt count)
+ * and re-queues any failed-but-still-eligible jobs.
+ */
+function tina4QueueRetry(array $args): void
+{
+    [, $positional] = parseFlags($args);
+    $topic = $positional[0] ?? 'default';
+
+    $queue = new \Tina4\Queue(topic: $topic);
+
+    // maxRetries=0 => every job in the dead-letter store, whatever its attempt
+    // count (matches what stats/size('dead') reports), not only attempts>=N.
+    $dead = $queue->deadLetters(0);
+    $revived = 0;
+    foreach ($dead as $job) {
+        if ($queue->retry((string)($job['id'] ?? ''))) {
+            $revived++;
+        }
+    }
+    // Any failed-but-retryable jobs still under the limit.
+    $requeued = $queue->retryFailed();
+
+    $total = $revived + $requeued;
+    echo "  Re-queued {$total} job(s) on '{$topic}' ({$revived} dead-letter, {$requeued} failed).\n";
+}
+
+/**
+ * queue clear — purge jobs of a given status (default: completed).
+ *
+ *   tina4php queue clear [status] [topic]
+ *
+ * status is one of pending / reserved / completed / failed / dead. The default
+ * 'completed' clears finished jobs; pass e.g. `queue clear pending` or
+ * `queue clear dead orders` to purge another status / topic.
+ */
+function tina4QueueClear(array $args): void
+{
+    [, $positional] = parseFlags($args);
+    $status = $positional[0] ?? 'completed';
+    $topic = $positional[1] ?? 'default';
+
+    $queue = new \Tina4\Queue(topic: $topic);
+    $removed = $queue->purge($status);
+    echo "  Cleared {$removed} '{$status}' job(s) from '{$topic}'.\n";
+}
+
+/**
+ * Top-level `queue` dispatch: run workers and manage jobs.
+ *
+ *   tina4php queue work  [topic] [--once] [--poll N] [--services DIR]
+ *   tina4php queue stats [topic] [--json]
+ *   tina4php queue retry [topic]
+ *   tina4php queue clear [status] [topic]
+ */
+function tina4Queue(array $args, array $subcommands): void
+{
+    if (empty($args)) {
+        echo "Usage: tina4php queue <work|stats|retry|clear> [options]\n";
+        echo "  Subcommands: " . implode(', ', $subcommands) . "\n";
+        exit(1);
+    }
+    $sub = strtolower($args[0]);
+    $rest = array_slice($args, 1);
+    switch ($sub) {
+        case 'work':
+            tina4QueueWork($rest);
+            break;
+        case 'stats':
+            tina4QueueStats($rest);
+            break;
+        case 'retry':
+            tina4QueueRetry($rest);
+            break;
+        case 'clear':
+            tina4QueueClear($rest);
+            break;
+        default:
+            echo "Unknown queue subcommand: {$sub}\n";
+            echo "  Available: " . implode(', ', $subcommands) . "\n";
+            exit(1);
+    }
+}
+
+
+// ════════════════════════════════════════════════════════════════════════
+// Build command — build the deployable Docker image
+// ════════════════════════════════════════════════════════════════════════
+//
+// A Tina4 app deploys as a container (`tina4php init` / `tina4 deploy docker`
+// scaffold a Dockerfile), so `build` produces THAT artifact: the image. It
+// shells out to the `docker` CLI (no new dependency) and fails loud with
+// guidance when there is no Dockerfile or docker is not on PATH. Mirrors the
+// Python master's _build (the Run: hint uses the PHP dev-server port, 7145).
+
+/**
+ * build — build the deployable Docker image for this Tina4 app.
+ *
+ *   tina4php build                    # docker build -t <dir>:latest -f Dockerfile .
+ *   tina4php build --tag myapp:1.2    # explicit image tag
+ *   tina4php build --file docker/uv/Dockerfile
+ */
+function tina4Build(array $args): void
+{
+    [$flags, ] = parseFlags($args);
+
+    $tag = $flags['tag'] ?? null;
+    if (!$tag || $tag === true) {
+        // Default tag: <project-folder>:latest, lower-cased (docker repo names
+        // must be lowercase). Fall back to a sane name for an unnamed cwd.
+        $dirName = strtolower(basename(getcwd() ?: ''));
+        if ($dirName === '') {
+            $dirName = 'tina4app';
+        }
+        $tag = "{$dirName}:latest";
+    }
+
+    $dockerfile = $flags['file'] ?? 'Dockerfile';
+    if ($dockerfile === true) {
+        $dockerfile = 'Dockerfile';
+    }
+
+    if (!is_file($dockerfile)) {
+        echo "  ✗ No {$dockerfile} found.\n";
+        echo "  A Tina4 app deploys as a container. Scaffold a Dockerfile first:\n";
+        echo "      tina4 deploy docker        (or: tina4php init)\n";
+        exit(1);
+    }
+
+    $docker = tina4Which('docker');
+    if ($docker === null) {
+        echo "  ✗ docker was not found on PATH.\n";
+        echo "  Install Docker to build the deployable image, or build manually:\n";
+        echo "      docker build -t {$tag} -f {$dockerfile} .\n";
+        exit(1);
+    }
+
+    echo "  Building image {$tag} from {$dockerfile} ...\n";
+    $cmd = escapeshellarg($docker) . ' build -t ' . escapeshellarg($tag)
+         . ' -f ' . escapeshellarg($dockerfile) . ' ' . escapeshellarg('.');
+    $returnCode = 0;
+    passthru($cmd, $returnCode);
+    if ($returnCode !== 0) {
+        echo "  ✗ docker build failed (exit {$returnCode})\n";
+        exit($returnCode);
+    }
+    echo "  ✓ Built image {$tag}\n";
+    echo "  Run: docker run -p 7145:7145 {$tag}\n";
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -85,6 +85,8 @@
             <file>tests/MetricsCliTest.php</file>
             <file>tests/CLIScaffoldingTest.php</file>
             <file>tests/CommandsManifestTest.php</file>
+            <file>tests/CliQueueTest.php</file>
+            <file>tests/CliBuildTest.php</file>
             <file>tests/CsrfMiddlewareTest.php</file>
             <file>tests/GalleryTest.php</file>
             <file>tests/LiveReloadTest.php</file>

--- a/tests/CliBuildTest.php
+++ b/tests/CliBuildTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Real tests for the corrected `build` CLI command (Phase 3, PHP mirror of the
+ * Python master's tests/test_cli_build.py).
+ *
+ * `build` produces the deployable Docker image (the artifact a Tina4 app ships),
+ * not a library package. NO mocks — these drive the REAL `bin/tina4php` as a
+ * subprocess:
+ *
+ *   * the fail-loud guards run against a real filesystem and a real, genuinely
+ *     empty PATH (so the CLI's `which docker` really finds nothing);
+ *   * when a real Docker daemon is available, a real `docker build` of a
+ *     network-free `FROM scratch` image is run and the resulting image is
+ *     inspected in the daemon, then cleaned up. Skipped (loudly) only when no
+ *     docker daemon is reachable.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CliBuildTest extends TestCase
+{
+    private static string $bin;
+    private string $dir; // temp project dir (the subprocess cwd)
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$bin = realpath(__DIR__ . '/../bin/tina4php');
+        self::assertNotFalse(self::$bin, 'bin/tina4php not found');
+    }
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/tina4-clibuild-' . getmypid() . '-' . uniqid();
+        mkdir($this->dir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_diff(scandir($this->dir), ['.', '..']) as $entry) {
+            @unlink($this->dir . '/' . $entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    /** True only when a real docker daemon is reachable. */
+    private static function dockerReady(): bool
+    {
+        $which = trim((string)@shell_exec('command -v docker 2>/dev/null'));
+        if ($which === '') {
+            return false;
+        }
+        @exec('docker info >/dev/null 2>&1', $_, $code);
+        return $code === 0;
+    }
+
+    /**
+     * Run the REAL build command in the temp project dir. $emptyPath makes the
+     * subprocess PATH contain only the dir holding the php binary (so `docker`
+     * is genuinely absent) — no mock of `which`.
+     */
+    private function runBuild(array $args, bool $emptyPath = false): array
+    {
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(self::$bin) . ' build';
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+
+        $env = getenv();
+        if ($emptyPath) {
+            // Keep only the php binary's own dir on PATH: docker is truly gone,
+            // but the interpreter still launches (invoked by absolute path anyway).
+            $env['PATH'] = dirname(PHP_BINARY);
+        }
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->dir, $env);
+        self::assertIsResource($process, 'failed to start bin/tina4php build');
+
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+
+        return [$out, $err, $exit];
+    }
+
+    // ── fail-loud guards ───────────────────────────────────────────────────
+
+    public function testNoDockerfileFailsLoud(): void
+    {
+        [$out, , $exit] = $this->runBuild([]);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('No Dockerfile', $out);
+        $this->assertStringContainsString('tina4 deploy docker', $out); // actionable guidance
+    }
+
+    public function testDockerfilePresentButDockerAbsentFailsLoud(): void
+    {
+        file_put_contents($this->dir . '/Dockerfile', "FROM scratch\n");
+        // Real 'docker missing': an emptied PATH makes the CLI's `which docker`
+        // return nothing. No mock — the environment really has no docker on PATH.
+        [$out, , $exit] = $this->runBuild([], emptyPath: true);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('docker', strtolower($out));
+    }
+
+    public function testCustomFileFlagMissingFailsLoud(): void
+    {
+        [$out, , $exit] = $this->runBuild(['--file', 'docker/prod/Dockerfile']);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('docker/prod/Dockerfile', $out);
+    }
+
+    // ── real image build ─────────────────────────────────────────────────
+
+    public function testBuildsScratchImageForReal(): void
+    {
+        if (!self::dockerReady()) {
+            $this->markTestSkipped('docker daemon not available (skipping REAL build; guards still covered)');
+        }
+
+        // FROM scratch needs no registry pull -> a real, offline docker build.
+        file_put_contents($this->dir . '/Dockerfile', "FROM scratch\n");
+        $tag = 'tina4-php-build-test:latest';
+        try {
+            [$out, , $exit] = $this->runBuild(['--tag', $tag]);
+            $this->assertSame(0, $exit, "build failed:\n{$out}");
+            $this->assertStringContainsString("Built image {$tag}", $out);
+            $this->assertStringContainsString('docker run -p 7145:7145', $out); // PHP dev-server port
+
+            // The real artifact exists in the docker daemon.
+            @exec('docker image inspect ' . escapeshellarg($tag) . ' >/dev/null 2>&1', $_, $code);
+            $this->assertSame(0, $code, 'built image not found in the docker daemon');
+        } finally {
+            @exec('docker image rm -f ' . escapeshellarg($tag) . ' >/dev/null 2>&1');
+        }
+    }
+}

--- a/tests/CliQueueTest.php
+++ b/tests/CliQueueTest.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Real tests for the top-level `queue` CLI command (Phase 3, PHP mirror of the
+ * Python master's tests/test_cli_queue.py).
+ *
+ * NO mocks. Every test drives the ACTUAL `bin/tina4php` entrypoint as a real
+ * subprocess (exactly how the tina4 Rust client drives it) against a REAL
+ * file-backed \Tina4\Queue rooted under a temp dir: push real jobs, run
+ * `work` / `stats` / `retry` / `clear`, and assert the real on-disk counts and
+ * side effects. `work` is exercised as a bounded single-pass drain (`--once`)
+ * running a REAL consumer file (real per-job handler, real processing) — no
+ * mock and no leaked worker.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CliQueueTest extends TestCase
+{
+    private static string $bin;
+
+    private string $work;   // temp workdir (also the subprocess cwd)
+    private string $qp;     // real file-backed queue path
+    private string $svc;    // services dir holding the real consumer file
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$bin = realpath(__DIR__ . '/../bin/tina4php');
+        self::assertNotFalse(self::$bin, 'bin/tina4php not found');
+    }
+
+    protected function setUp(): void
+    {
+        $this->work = sys_get_temp_dir() . '/tina4-cliqueue-' . getmypid() . '-' . uniqid();
+        $this->qp = $this->work . '/queue';
+        $this->svc = $this->work . '/svc';
+        mkdir($this->svc, 0755, true);
+
+        // Force a clean, isolated file backend for both the test-process Queue
+        // and the CLI subprocess (which inherits this env via getenv()).
+        putenv('TINA4_QUEUE_BACKEND=file');
+        putenv('TINA4_QUEUE_PATH=' . $this->qp);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('TINA4_QUEUE_BACKEND');
+        putenv('TINA4_QUEUE_PATH');
+        $this->rmrf($this->work);
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff(scandir($dir), ['.', '..']) as $entry) {
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * A real file-backed Queue in the test process, pointed at the SAME path
+     * the CLI subprocess uses — so jobs pushed here are the jobs the CLI sees,
+     * and counts asserted here are the CLI's real on-disk state.
+     */
+    private function queue(string $topic, array $config = []): \Tina4\Queue
+    {
+        return new \Tina4\Queue('file', array_merge(['path' => $this->qp], $config), $topic);
+    }
+
+    /** Drive the REAL bin/tina4php as the tina4 client would. Returns [out, err, exit]. */
+    private function runCli(array $args): array
+    {
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(self::$bin);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+
+        $env = getenv();
+        $env['TINA4_QUEUE_BACKEND'] = 'file';
+        $env['TINA4_QUEUE_PATH'] = $this->qp;
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->work, $env);
+        self::assertIsResource($process, 'failed to start bin/tina4php');
+
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+
+        return [$out, $err, $exit];
+    }
+
+    /**
+     * Write a REAL consumer file exposing topic + per-job handle, the shape
+     * `generate queue <topic>` scaffolds. The handle appends each job's n to a
+     * results file (a real, observable side effect) and throws on a poison job.
+     */
+    private function writeConsumer(string $topic, string $resultsFile): void
+    {
+        $rf = var_export($resultsFile, true);
+        $tp = var_export($topic, true);
+        file_put_contents(
+            $this->svc . "/{$topic}_consumer.php",
+            "<?php\n"
+            . "\$handle = function (array \$data): void {\n"
+            . "    \$results = {$rf};\n"
+            . "    if (!empty(\$data['boom'])) { throw new \\RuntimeException('boom'); }\n"
+            . "    file_put_contents(\$results, \$data['n'] . \"\\n\", FILE_APPEND);\n"
+            . "};\n"
+            . "return ['name' => {$tp} . '-consumer', 'topic' => {$tp}, 'handle' => \$handle, 'daemon' => true];\n"
+        );
+    }
+
+    // ── stats ────────────────────────────────────────────────────────────
+
+    public function testStatsReportsRealPendingCount(): void
+    {
+        $q = $this->queue('emails');
+        $q->push(['n' => 1]);
+        $q->push(['n' => 2]);
+        $q->push(['n' => 3]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'stats', 'emails']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('pending    3', $out);
+    }
+
+    public function testStatsJsonIsMachineReadableAndExact(): void
+    {
+        $this->queue('emails')->push(['n' => 1]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'stats', 'emails', '--json']);
+        $this->assertSame(0, $exit);
+        $this->assertSame(
+            ['topic' => 'emails', 'pending' => 1, 'reserved' => 0, 'failed' => 0, 'dead' => 0, 'completed' => 0],
+            json_decode($out, true)
+        );
+    }
+
+    public function testStatsDeadCountViaRealJobLifecycle(): void
+    {
+        // Create a real dead-letter through the Job lifecycle: max_retries=1 so
+        // the first fail() dead-letters it. Then the CLI must report dead == 1.
+        $q = $this->queue('emails', ['maxRetries' => 1]);
+        $q->push(['n' => 1]);
+        foreach ($q->consume('emails', null, 0.0) as $job) {
+            $job->fail('boom');    // attempts 1 >= maxRetries 1 -> dead-letter
+            break;
+        }
+        $this->assertSame(1, $this->queue('emails')->size('dead'), 'setup: expected a real dead-letter');
+
+        [$out, , $exit] = $this->runCli(['queue', 'stats', 'emails', '--json']);
+        $this->assertSame(0, $exit);
+        $this->assertSame(1, json_decode($out, true)['dead']);
+    }
+
+    public function testStatsDefaultTopicWhenOmitted(): void
+    {
+        $this->queue('default')->push(['n' => 1]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'stats']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString("Queue 'default'", $out);
+        $this->assertStringContainsString('pending    1', $out);
+    }
+
+    // ── retry ────────────────────────────────────────────────────────────
+
+    public function testRetryRevivesDeadLetterJobBackToPending(): void
+    {
+        $q = $this->queue('jobs', ['maxRetries' => 1]);
+        $q->push(['n' => 1]);
+        foreach ($q->consume('jobs', null, 0.0) as $job) {
+            $job->fail('boom');    // -> dead-letter
+            break;
+        }
+        $this->assertSame(1, $this->queue('jobs')->size('dead'));
+
+        [$out, , $exit] = $this->runCli(['queue', 'retry', 'jobs']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Re-queued 1 job(s)', $out);
+
+        // Real files moved out of the dead-letter store back to pending.
+        $this->assertSame(1, $this->queue('jobs')->size('pending'));
+        $this->assertSame(0, $this->queue('jobs')->size('dead'));
+    }
+
+    public function testRetryNothingToRetryIsZero(): void
+    {
+        [$out, , $exit] = $this->runCli(['queue', 'retry', 'jobs']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Re-queued 0 job(s)', $out);
+    }
+
+    // ── clear ────────────────────────────────────────────────────────────
+
+    public function testClearPendingPurgesRealJobs(): void
+    {
+        $q = $this->queue('tasks');
+        $q->push(['n' => 1]);
+        $q->push(['n' => 2]);
+        $this->assertSame(2, $q->size('pending'));
+
+        [$out, , $exit] = $this->runCli(['queue', 'clear', 'pending', 'tasks']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString("Cleared 2 'pending' job(s)", $out);
+        $this->assertSame(0, $this->queue('tasks')->size('pending'));
+    }
+
+    public function testClearDefaultsToCompletedAndDefaultTopic(): void
+    {
+        $this->queue('tasks')->push(['n' => 1]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'clear']); // status=completed, topic=default
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString("Cleared 0 'completed' job(s)", $out);
+        // A completed-clear on the default topic leaves the tasks topic intact.
+        $this->assertSame(1, $this->queue('tasks')->size('pending'));
+    }
+
+    public function testClearDeadLetter(): void
+    {
+        $q = $this->queue('tasks', ['maxRetries' => 1]);
+        $q->push(['n' => 1]);
+        foreach ($q->consume('tasks', null, 0.0) as $job) {
+            $job->fail('boom');    // -> dead-letter
+            break;
+        }
+        $this->assertSame(1, $this->queue('tasks')->size('dead'));
+
+        [$out, , $exit] = $this->runCli(['queue', 'clear', 'dead', 'tasks']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString("Cleared 1 'dead' job(s)", $out);
+        $this->assertSame(0, $this->queue('tasks')->size('dead'));
+    }
+
+    // ── work ─────────────────────────────────────────────────────────────
+
+    public function testWorkOnceDrainsAndProcessesRealJobs(): void
+    {
+        $results = $this->work . '/results.txt';
+        $this->writeConsumer('greetings', $results);
+
+        $q = $this->queue('greetings');
+        $q->push(['n' => 1]);
+        $q->push(['n' => 2]);
+        $q->push(['n' => 3]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'work', 'greetings', '--once', '--services', $this->svc]);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Processed 3 job(s), 0 failed', $out);
+
+        // The REAL handler ran for every job (real side effect on disk).
+        $lines = array_values(array_filter(explode("\n", trim((string)@file_get_contents($results)))));
+        sort($lines);
+        $this->assertSame(['1', '2', '3'], $lines);
+        $this->assertSame(0, $this->queue('greetings')->size('pending'));
+    }
+
+    public function testWorkOnceNacksFailingJobToDeadLetter(): void
+    {
+        $results = $this->work . '/results.txt';
+        $this->writeConsumer('greetings', $results);
+
+        $q = $this->queue('greetings');
+        $q->push(['n' => 1]);        // good
+        $q->push(['boom' => true]);  // poison
+
+        [$out, , $exit] = $this->runCli(['queue', 'work', 'greetings', '--once', '--services', $this->svc]);
+        $this->assertSame(0, $exit);
+
+        // Good job processed; poison job burned its retries -> dead-letter.
+        $this->assertSame('1', trim((string)@file_get_contents($results)));
+        $this->assertSame(1, $this->queue('greetings')->size('dead'));
+        $this->assertStringContainsString('Processed 1 job(s)', $out);
+    }
+
+    public function testWorkOnceWithoutHandlerWarnsAndDrains(): void
+    {
+        $this->queue('orphans')->push(['n' => 1]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'work', 'orphans', '--once', '--services', $this->work . '/nope']);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('No consumer handler found', $out);
+        $this->assertStringContainsString('Processed 1 job(s)', $out);
+        $this->assertSame(0, $this->queue('orphans')->size('pending'));
+    }
+
+    public function testWorkResolvesHandlerByTopicNotWrongSibling(): void
+    {
+        // A sibling consumer for a DIFFERENT topic must not be driven — proves
+        // the real resolver matches on topic, end to end.
+        $results = $this->work . '/results.txt';
+        $this->writeConsumer('other', $results);   // wrong topic on disk
+        $this->queue('greetings')->push(['n' => 9]);
+
+        [$out, , $exit] = $this->runCli(['queue', 'work', 'greetings', '--once', '--services', $this->svc]);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('No consumer handler found', $out); // no matching topic
+        $this->assertFileDoesNotExist($results);                              // handler never ran
+        $this->assertStringContainsString('Processed 1 job(s)', $out);        // still drained + acked
+    }
+
+    // ── dispatch guards ────────────────────────────────────────────────────
+
+    public function testNoSubcommandExitsNonZero(): void
+    {
+        [$out, , $exit] = $this->runCli(['queue']);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('work', $out);
+    }
+
+    public function testUnknownSubcommandExitsNonZero(): void
+    {
+        [$out, , $exit] = $this->runCli(['queue', 'frobnicate']);
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('Unknown queue subcommand', $out);
+    }
+}

--- a/tests/CommandsManifestTest.php
+++ b/tests/CommandsManifestTest.php
@@ -30,6 +30,7 @@ class CommandsManifestTest extends TestCase
     /** The command set the tina4 client must be able to discover truthfully. */
     private const KNOWN_COMMANDS = [
         'migrate', 'migrate:create', 'seed', 'test', 'routes', 'generate', 'commands',
+        'queue', 'build',
     ];
 
     private static string $bin;
@@ -154,22 +155,45 @@ class CommandsManifestTest extends TestCase
         $this->assertSame(['description'], $entry['args'] ?? null);
     }
 
-    public function testNoInventedTopLevelQueueCommand(): void
+    public function testQueueIsATopLevelCommandAndAGenerator(): void
     {
-        // `queue` exists only as a `generate` subcommand today — it must NOT
-        // masquerade as a top-level command (parity with the Python master).
+        // Phase 3: `queue` is now BOTH a top-level command (run workers / manage
+        // jobs) with work/stats/retry/clear subcommands, AND a `generate`
+        // subcommand (scaffold a consumer). The two are distinct surfaces —
+        // parity with the Python master.
         $manifest = $this->manifest();
         $names = array_column($manifest['commands'], 'name');
-        $this->assertNotContains('queue', $names);
+        $this->assertContains('queue', $names, 'top-level queue command missing from manifest');
 
+        $queue = null;
         $generate = null;
         foreach ($manifest['commands'] as $c) {
+            if ($c['name'] === 'queue') {
+                $queue = $c;
+            }
             if ($c['name'] === 'generate') {
                 $generate = $c;
+            }
+        }
+        $this->assertNotNull($queue);
+        $this->assertSame(['work', 'stats', 'retry', 'clear'], $queue['subcommands'] ?? null);
+
+        // Still a scaffolding generator too (unchanged).
+        $this->assertContains('queue', $generate['subcommands'] ?? []);
+    }
+
+    public function testBuildDeclaresDeployOrientedSummary(): void
+    {
+        // `build` produces the deployable Docker image, not a library package.
+        $entry = null;
+        foreach ($this->manifest()['commands'] as $c) {
+            if ($c['name'] === 'build') {
+                $entry = $c;
                 break;
             }
         }
-        $this->assertContains('queue', $generate['subcommands'] ?? []);
+        $this->assertNotNull($entry, 'no build command in manifest');
+        $this->assertStringContainsString('Docker', $entry['summary']);
     }
 
     // ── Anti-drift lock-in ───────────────────────────────────────────────


### PR DESCRIPTION
Mirrors the Phase 3 Python-master contract (tina4-python #86): top-level `queue` (work/stats/retry/clear) wired to the real Queue, `build` = real `docker build` (replacing/adding vs the prior state), `generate queue` scaffold gains topic/handle, manifest advertises both. Also fixes: PHP had NO top-level queue (generator-only) and build was an 'not yet implemented' stub.

Independently re-verified at HEAD (own suite re-run + diff read). `commands --json` queue/build entries match Python byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)