### PR TITLE
release: 3.13.67 — MCP database_tables fix (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.66 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.67 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 

--- a/Tina4/MCP.php
+++ b/Tina4/MCP.php
@@ -20,7 +20,7 @@
  *     }, "Find invoice by number");
  *
  *     $mcp->registerResource("app://schema", function() use ($db) {
- *         return $db->getDatabase();
+ *         return $db->getTables();
  *     }, "Database schema");
  *
  * Built-in dev tools auto-register when TINA4_DEBUG=true and running on localhost.
@@ -1269,7 +1269,12 @@ class McpDevTools
             } catch (\Throwable $e) {
                 return ['error' => 'No database connection: ' . $e->getMessage()];
             }
-            return $db->getDatabase();
+            // BUGFIX (#164): getDatabase() is not defined on the base Database
+            // (only on concrete adapters, where it returns the db-name string).
+            // getTables() is the DatabaseAdapter contract that lists tables and
+            // matches Python master (db.get_tables()) / Ruby (db.tables) / Node
+            // (db.getTables()). The old call fataled on every invocation.
+            return $db->getTables();
         }, 'List all database tables');
 
         $server->registerTool('database_columns', function (string $table) {
@@ -2053,7 +2058,7 @@ function mcp_tool(string $name = '', string $description = '', ?McpServer $serve
  *
  * Usage:
  *     mcp_resource("app://schema", "Database schema")(function() use ($db) {
- *         return $db->getDatabase();
+ *         return $db->getTables();
  *     });
  *
  * @param string          $uri         Resource URI

--- a/tests/CliBuildTest.php
+++ b/tests/CliBuildTest.php
@@ -59,9 +59,10 @@ class CliBuildTest extends TestCase
     }
 
     /**
-     * Run the REAL build command in the temp project dir. $emptyPath makes the
-     * subprocess PATH contain only the dir holding the php binary (so `docker`
-     * is genuinely absent) — no mock of `which`.
+     * Run the REAL build command in the temp project dir. $emptyPath points the
+     * subprocess PATH at a GENUINELY EMPTY directory so `docker` is truly absent
+     * (no mock of `which`). php and /bin/sh are invoked by absolute path, so
+     * neither needs to be on PATH.
      */
     private function runBuild(array $args, bool $emptyPath = false): array
     {
@@ -72,9 +73,16 @@ class CliBuildTest extends TestCase
 
         $env = getenv();
         if ($emptyPath) {
-            // Keep only the php binary's own dir on PATH: docker is truly gone,
-            // but the interpreter still launches (invoked by absolute path anyway).
-            $env['PATH'] = dirname(PHP_BINARY);
+            // Point PATH at an EMPTY dir so the CLI's docker lookup finds nothing.
+            // (The old `dirname(PHP_BINARY)` did NOT hide docker on CI, where php
+            // and docker share /usr/bin — so `build` found docker and exited 0,
+            // failing the docker-absent guard. Mirrors the Python master test's
+            // genuinely-empty PATH. php is launched by absolute path regardless.)
+            $emptyBin = $this->dir . '/emptybin';
+            if (!is_dir($emptyBin)) {
+                mkdir($emptyBin, 0777, true);
+            }
+            $env['PATH'] = $emptyBin;
         }
 
         $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];

--- a/tests/MCPTest.php
+++ b/tests/MCPTest.php
@@ -728,6 +728,62 @@ class MCPTest extends TestCase
         }
     }
 
+    /**
+     * Regression (#164): the database_tables dev-tool must actually LIST tables.
+     * It called $db->getDatabase() — undefined on the base Database returned by
+     * fromEnv() — so every invocation fataled with "Call to undefined method".
+     * The registration-only test above never caught it because it only asserts
+     * the tool is present, never INVOKES it. This test invokes the real handler
+     * against a REAL SQLite database (no mock) and asserts a table list comes
+     * back. Locks the contract that matches Python master (db.get_tables()),
+     * Ruby (db.tables) and Node (db.getTables()).
+     */
+    public function testDatabaseTablesToolListsRealTables(): void
+    {
+        $tmpDb = sys_get_temp_dir() . '/tina4_mcp164_' . uniqid() . '.db';
+        $url = 'sqlite:///' . $tmpDb;               // abs temp path -> sqlite:////... (absolute)
+        $prevEnv = getenv('TINA4_DATABASE_URL');
+        $_ENV['TINA4_DATABASE_URL'] = $url;
+        putenv('TINA4_DATABASE_URL=' . $url);
+        \Tina4\DotEnv::resetEnv();                  // so fromEnv() picks up the override
+
+        try {
+            // Real database, real table — no mock, no stub.
+            $db = \Tina4\Database\Database::create($url);
+            $db->execute('CREATE TABLE mcp_probe_widget (id INTEGER PRIMARY KEY, name TEXT)');
+
+            $server = new McpServer('/db-tables', 'DB Tables Test');
+            McpDevTools::register($server);
+
+            $resp = json_decode($server->handleMessage([
+                'jsonrpc' => '2.0',
+                'id' => 1,
+                'method' => 'tools/call',
+                'params' => ['name' => 'database_tables', 'arguments' => []],
+            ]), true);
+
+            // Not a JSON-RPC error (a fatal/exception in the handler surfaces here).
+            $this->assertArrayNotHasKey('error', $resp, 'database_tables raised a JSON-RPC error: ' . json_encode($resp));
+            $text = $resp['result']['content'][0]['text'];
+            $this->assertStringNotContainsString('getDatabase', $text, 'the #164 undefined-method fatal is back');
+
+            $decoded = json_decode($text, true);
+            $this->assertIsArray($decoded, 'database_tables must return a list of tables, got: ' . $text);
+            $this->assertArrayNotHasKey('error', $decoded, 'database_tables returned an error payload: ' . $text);
+            $this->assertContains('mcp_probe_widget', $decoded, 'the created table should be listed');
+        } finally {
+            if ($prevEnv === false) {
+                unset($_ENV['TINA4_DATABASE_URL']);
+                putenv('TINA4_DATABASE_URL');
+            } else {
+                $_ENV['TINA4_DATABASE_URL'] = $prevEnv;
+                putenv('TINA4_DATABASE_URL=' . $prevEnv);
+            }
+            \Tina4\DotEnv::resetEnv();
+            @unlink($tmpDb);
+        }
+    }
+
     public function testGetToolListShapeMatchesPython(): void
     {
         $server = new McpServer('/rest-shape', 'Test');


### PR DESCRIPTION
## 3.13.67 — MCP database_tables fix (#164)

Fixes the PHP `database_tables` dev-tool, which called `getDatabase()` (undefined on the base `Database`) and fataled on every call. Now calls `getTables()`, matching Python `get_tables()` / Ruby `tables` / Node `getTables()`.

Cross-checked all four frameworks (feedback_crosscheck_bugs): the bug was PHP-only; Python/Ruby/Node already called the correct method. All four gain a real behavioural lock-in test that INVOKES the `database_tables` handler against a REAL SQLite database (no mock) and asserts a table list — the old tests only checked the tool was registered, which is why a guaranteed fatal shipped 3.13.14 → 3.13.66.

Reported by skorteva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)