### PR TITLE
chore(release): 3.13.68

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.67 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.68 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 


### PR DESCRIPTION
Release 3.13.68.

- **Firebird ORM count()/recordExists()** read the `COUNT(*) as cnt` alias case-insensitively (Firebird uppercases it to `CNT`), so `count()` no longer returns 0 on Firebird; `insert()` routes Firebird through `INSERT ... RETURNING` to backfill the identity PK (#132/#133). Verified no-mock vs real Firebird 5.0.2.
- tina4-maintainer skill plan-path docs fix (reference plans/files by repo-prefixed path so links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)