### PR TITLE
fix(cli): REPL reads TINA4_DATABASE_URL + creds + binds the ORM

### DIFF
--- a/bin/tina4php
+++ b/bin/tina4php
@@ -1277,16 +1277,22 @@ DOCKERFILE;
         // Initialize app
         $app = new \Tina4\App(basePath: $cwd);
 
-        // Try database
+        // Try database. Database::fromEnv() reads the canonical TINA4_DATABASE_URL
+        // AND the separate TINA4_DATABASE_USERNAME/PASSWORD (the documented Tina4
+        // convention keeps credentials out of the URL). Bind it so the $db handle
+        // and the ORM models share ONE connected instance. Previously this read the
+        // LEGACY 'DATABASE_URL' key (so $db was null when the user set the canonical
+        // TINA4_DATABASE_URL) and built the handle from the URL alone (no creds), so
+        // on every credentialed engine the REPL's $db was dead.
         $db = null;
-        $dbUrl = \Tina4\DotEnv::getEnv('DATABASE_URL');
-        if ($dbUrl) {
-            try {
-                $db = \Tina4\Database\Database::create($dbUrl);
-                echo "  Database: {$dbUrl}\n";
-            } catch (\Throwable $e) {
-                echo "  Database: failed ({$e->getMessage()})\n";
+        try {
+            $db = \Tina4\Database\Database::fromEnv();
+            if ($db !== null) {
+                \Tina4\ORM::bindDatabase($db);
+                echo "  Database: " . \Tina4\DotEnv::getEnv('TINA4_DATABASE_URL') . "\n";
             }
+        } catch (\Throwable $e) {
+            echo "  Database: failed ({$e->getMessage()})\n";
         }
 
         echo "\n  Tina4 PHP Console\n";


### PR DESCRIPTION
`tina4php console` had three DB-environment bugs:
1. It read the **legacy** `DATABASE_URL` key, not the canonical `TINA4_DATABASE_URL` — so `$db` was `null` whenever the user configured the documented env var (i.e. almost always).
2. It built the handle from the URL alone, dropping `TINA4_DATABASE_USERNAME`/`TINA4_DATABASE_PASSWORD`.
3. It never bound the ORM.

**Fix:** use `Database::fromEnv()` (canonical URL + separate credentials) + `ORM::bindDatabase($db)`, so `$db` connects on credentialed engines and the handle + models share one instance.

**Verified live** vs real Firebird 5.0.2 (pdo fallback): OLD `getEnv('DATABASE_URL')` → `null`; NEW `fromEnv()` → `PdoFirebirdAdapter`, `fetchOne` returns `{"OK":1}`. `bin/tina4php` is lint-clean.

Mirrors the Python master fix. Ruby/Node consoles were already correct (they route through the credential-aware `initialize!` / `initDatabase` bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)