### PR TITLE
fix(migration): a passed = 0 row is pending even when migration_id remains

### DIFF
--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -338,6 +338,14 @@ class Migration
     /**
      * Get the list of pending migration files.
      *
+     * A file is pending unless the bookkeeping table records it as applied.
+     * Applied means a row with `passed = 1`, keyed on `migration_name` — or, on
+     * a table still carrying the legacy `migration_id` column, on the 14-char
+     * timestamp prefix that was the v2 identifier (where a NULL `passed` also
+     * counts as applied, as the in-place upgrade reads it). A `passed = 0` row
+     * is not applied under either key, so its migration is reported pending and
+     * re-applies on the next `migrate()`.
+     *
      * @return array<string> Full file paths
      */
     public function getPendingMigrations(): array
@@ -350,9 +358,22 @@ class Migration
         // `migration` backfill did not resolve to the current filename — still
         // records that the migration ran; matching the prefix stops it being
         // re-applied. Keyed as prefix => true for O(1) lookup.
+        //
+        // Only a row that does NOT record a failure suppresses its file. Without
+        // this a `passed = 0` row is excluded from the applied set yet still
+        // matched here, leaving its migration neither applied nor pending —
+        // invisible, and held out of the run solely by a legacy column that is
+        // slated for removal (#129).
+        //
+        // A NULL `passed` counts as applied, matching how the in-place upgrade
+        // reads legacy rows ("existing rows were only ever written when
+        // applied"): the v2 shape declares `passed INTEGER` with no default, and
+        // only the older-v3 upgrade path backfills NULL -> 1, so a v2-upgraded
+        // table can still hold NULLs here. COALESCE keeps them suppressed rather
+        // than silently re-running them.
         $appliedPrefixes = [];
         if ($this->hasLegacyMigrationIdColumn()) {
-            foreach ($this->queryLower("SELECT migration_id FROM " . self::MIGRATIONS_TABLE) as $row) {
+            foreach ($this->queryLower("SELECT migration_id FROM " . self::MIGRATIONS_TABLE . " WHERE COALESCE(passed, 1) <> 0") as $row) {
                 $prefix = trim((string) ($row['migration_id'] ?? ''));
                 if ($prefix !== '') {
                     $appliedPrefixes[$prefix] = true;

--- a/tests/MigrationPassedColumnTest.php
+++ b/tests/MigrationPassedColumnTest.php
@@ -288,4 +288,151 @@ class MigrationPassedColumnTest extends TestCase
         // Its effect table is untouched (not dropped / not recreated).
         $this->assertTrue($this->db->tableExists('v2_applied_effect'));
     }
+
+    // -----------------------------------------------------------------
+    // 5. On a table that RETAINS `migration_id`, a passed = 0 row whose
+    //    file IS on disk is still reported pending and re-applies.
+    //
+    //    Test 3 pins the same contract on a fresh v3 table, which has no
+    //    `migration_id` column, so the legacy prefix lookup never engages.
+    //    Test 4 keeps its passed = 0 row's file deliberately absent. This
+    //    covers the combination both leave out — and it is the shape a real
+    //    v2 -> v3 in-place upgrade produces.
+    // -----------------------------------------------------------------
+
+    public function testPassedZeroRowOnLegacyMigrationIdTableIsPendingAndReApplies(): void
+    {
+        // The PHP v2 shape exactly as tina4-php ^2.x created it.
+        $this->db->execute(
+            "CREATE TABLE tina4_migration (
+                migration_id VARCHAR(14) NOT NULL PRIMARY KEY,
+                description VARCHAR(1000),
+                content BLOB,
+                passed INTEGER
+            )"
+        );
+
+        // A passed = 0 row whose file IS present: the migration did not complete,
+        // so its effect table does not exist and it must run again.
+        $fileName = '20240103000000_create_widgets.sql';
+        $this->db->execute(
+            "INSERT INTO tina4_migration (migration_id, description, passed) VALUES ('20240103000000', 'create widgets', 0)"
+        );
+        file_put_contents(
+            $this->migrationsDir . '/' . $fileName,
+            'CREATE TABLE widgets (id INTEGER PRIMARY KEY)'
+        );
+
+        // Constructing the runner performs the in-place v2 -> v3 upgrade.
+        $migration = new Migration($this->db, $this->migrationsDir);
+
+        // Precondition: the legacy prefix column survives the upgrade, which is
+        // what makes this shape different from a fresh v3 table.
+        $this->assertContains('migration_id', $this->trackingColumns());
+        $this->assertSame(0, $this->passedFor($fileName), 'precondition: the row is still passed = 0 after the upgrade');
+
+        // NOT applied — getAppliedMigrations reads WHERE passed = 1.
+        $appliedNames = array_column($migration->getAppliedMigrations(), 'migration_name');
+        $this->assertNotContains($fileName, $appliedNames, 'a passed = 0 row must NOT count as applied');
+
+        // IS pending. Previously the legacy prefix lookup matched this row
+        // regardless of `passed`, so the file was neither applied nor pending —
+        // held out of the run only by `migration_id`.
+        $pending = array_map('basename', $migration->getPendingMigrations());
+        $this->assertContains($fileName, $pending, 'a passed = 0 migration must be pending even when migration_id is present');
+        $this->assertFalse($this->db->tableExists('widgets'), 'precondition: the migration has not run');
+
+        // It re-applies cleanly, and the stale row is superseded rather than duplicated.
+        $result = $migration->migrate();
+        $this->assertContains($fileName, $result['applied'], 'the passed = 0 migration must re-apply');
+        $this->assertSame([], $result['errors'], 'a clean re-apply must report no errors');
+        $this->assertTrue($this->db->tableExists('widgets'), 'the re-apply must have created its DDL');
+        $this->assertSame(1, $this->passedFor($fileName), 'the surviving row must be passed = 1');
+        $this->assertNotContains($fileName, array_map('basename', $migration->getPendingMigrations()));
+    }
+
+    // -----------------------------------------------------------------
+    // 6. The prefix lookup still suppresses a passed = 1 legacy row —
+    //    narrowing it to passed = 1 must not re-run applied migrations.
+    // -----------------------------------------------------------------
+
+    public function testPassedOneLegacyRowStillSuppressesItsFileByPrefix(): void
+    {
+        $this->db->execute(
+            "CREATE TABLE tina4_migration (
+                migration_id VARCHAR(14) NOT NULL PRIMARY KEY,
+                description VARCHAR(1000),
+                content BLOB,
+                passed INTEGER
+            )"
+        );
+
+        // An applied v2 row whose file on disk is named DIFFERENTLY from the
+        // description, so only the 14-char prefix can match it. Re-running it
+        // would fail: its effect table already exists.
+        $fileName = '20240104000000_create_sprockets.sql';
+        $this->db->execute(
+            "INSERT INTO tina4_migration (migration_id, description, passed) VALUES ('20240104000000', 'legacy name', 1)"
+        );
+        $this->db->execute('CREATE TABLE sprockets (id INTEGER PRIMARY KEY)');
+        file_put_contents(
+            $this->migrationsDir . '/' . $fileName,
+            'CREATE TABLE sprockets (id INTEGER PRIMARY KEY)'
+        );
+
+        $migration = new Migration($this->db, $this->migrationsDir);
+
+        $pending = array_map('basename', $migration->getPendingMigrations());
+        $this->assertNotContains($fileName, $pending, 'an applied legacy row must still suppress its file by prefix');
+
+        $result = $migration->migrate();
+        $this->assertSame([], $result['errors'], 'the applied migration must not be re-run into an error');
+        $this->assertNotContains($fileName, $result['applied']);
+    }
+
+    // -----------------------------------------------------------------
+    // 7. A legacy row with a NULL `passed` still suppresses its file.
+    //
+    //    The v2 shape declares `passed INTEGER` with no default, and only
+    //    the older-v3 upgrade path backfills NULL -> 1, so a v2-upgraded
+    //    table can still hold NULLs. The upgrade reads a legacy row as
+    //    applied ("existing rows were only ever written when applied"), so
+    //    an unknown `passed` must NOT re-run the migration.
+    // -----------------------------------------------------------------
+
+    public function testNullPassedLegacyRowStillSuppressesItsFileByPrefix(): void
+    {
+        $this->db->execute(
+            "CREATE TABLE tina4_migration (
+                migration_id VARCHAR(14) NOT NULL PRIMARY KEY,
+                description VARCHAR(1000),
+                content BLOB,
+                passed INTEGER
+            )"
+        );
+
+        // passed left NULL — the v2 column has no default.
+        $fileName = '20240105000000_create_cogs.sql';
+        $this->db->execute(
+            "INSERT INTO tina4_migration (migration_id, description, passed) VALUES ('20240105000000', 'create cogs', NULL)"
+        );
+        $this->db->execute('CREATE TABLE cogs (id INTEGER PRIMARY KEY)');
+        file_put_contents(
+            $this->migrationsDir . '/' . $fileName,
+            'CREATE TABLE cogs (id INTEGER PRIMARY KEY)'
+        );
+
+        $migration = new Migration($this->db, $this->migrationsDir);
+
+        $pending = array_map('basename', $migration->getPendingMigrations());
+        $this->assertNotContains(
+            $fileName,
+            $pending,
+            'a NULL passed legacy row must not be re-run — only passed = 0 records a failure'
+        );
+
+        $result = $migration->migrate();
+        $this->assertSame([], $result['errors']);
+        $this->assertNotContains($fileName, $result['applied']);
+    }
 }


### PR DESCRIPTION
Closes the remaining half of #172 — the part 3.13.73 could not reach.

## The gap

`getAppliedMigrations()` reads `WHERE passed = 1`, but `getPendingMigrations()` matched the legacy `migration_id` prefix from **every** row, with no `passed` filter:

```php
foreach ($this->queryLower("SELECT migration_id FROM " . self::MIGRATIONS_TABLE) as $row) {
    $appliedPrefixes[$prefix] = true;   // passed = 0 rows land here too
}
```

So on a table that still carries `migration_id`, a `passed = 0` row is **neither applied nor pending** — its migration silently never runs again, held out of the run solely by a legacy column that #129 proposes dropping.

This contradicts the documented contract:

> any `passed = 0` row (including one carried over from a v2 table) is treated as **not applied**, so it is reported pending

…for precisely the tables that sentence calls out, since the prefix lookup only engages when `migration_id` is present (`hasLegacyMigrationIdColumn()`).

It also makes 3.13.73's delete-before-insert unreachable on those tables: the file never becomes pending, so `migrate()` never runs it, so `recordMigration()` — and its DELETE — never fires. "A previously-failed migration re-applies cleanly" holds for fresh canonical tables, but not for the in-place-upgraded case the issue was filed from.

Verified on the real Firebird app in #172 under 3.13.77: 13 `passed = 0` rows whose up-migrations are on disk, `getAppliedMigrations()` → 21, `getPendingMigrations()` → **0**.

## The change

The prefix lookup now selects `WHERE COALESCE(passed, 1) <> 0` — only a row recording a **failure** stops suppressing its file.

**A NULL `passed` deliberately still counts as applied.** I had this as a bare `WHERE passed = 1` first; measuring every table shape showed it silently re-ran NULL rows. The v2 shape declares `passed INTEGER` with **no default**, and only `upgradeLegacyV3Schema()` backfills `NULL -> 1` — the v2→v3 path does not — so a v2-upgraded table can still hold NULLs at this point. The upgrade itself reads a legacy row as applied (*"existing rows were only ever written when applied"*), so re-running them would be wrong. `COALESCE` keeps the change surgical.

### Measured compatibility

Pending output across every shape, old code vs new — identical except the one case this fixes:

| table shape | old | new |
|---|---|---|
| fresh v3, nothing applied | pending | pending |
| fresh v3, applied `passed = 1` | – | – |
| older v3 (`migration`/`batch`/`applied_at`, no `migration_id`) | – | – |
| v2-upgraded, `passed = 1` | – | – |
| v2-upgraded, `passed = 0`, file absent | – | – |
| v2-upgraded, `passed = NULL` | – | – |
| **v2-upgraded, `passed = 0`, file present** | **–** | **pending** ← the fix |

Signature unchanged; no schema change; nothing added to the table.

## Adapter coverage

`passed` is guaranteed present wherever `migration_id` is, so the predicate is valid on **SQLite, MySQL, Postgres, Firebird and MSSQL** alike:
- the v2 shape (the only one carrying `migration_id`) always declares `passed`;
- `upgradeLegacyV3Schema()` adds `passed INTEGER DEFAULT 1` when absent.

Both run in the constructor, before any `getPendingMigrations()` call. `COALESCE` is standard SQL on all five.

## Tests

Real SQLite, no mocks, extending `MigrationPassedColumnTest` (7/7):

1. **`testPassedZeroRowOnLegacyMigrationIdTableIsPendingAndReApplies`** — a `passed = 0` row on a `migration_id` table whose file **is** on disk is pending and re-applies cleanly, leaving exactly one `passed = 1` row. **Fails without the fix.**
2. **`testPassedOneLegacyRowStillSuppressesItsFileByPrefix`** — a `passed = 1` legacy row still suppresses its file, so narrowing the lookup does not re-run applied migrations.
3. **`testNullPassedLegacyRowStillSuppressesItsFileByPrefix`** — **fails against the naive `WHERE passed = 1`**, pinning the NULL behaviour above.

That first combination was genuinely untested: `testPassedZeroRowReAppliesCleanlyOnMigrate` uses a **fresh v3 table**, which has no `migration_id` column, so the prefix lookup never engages; and `testV2TableWithPassed0RowUpgradesAndAppliedNotRerun` keeps its `passed = 0` row's file *deliberately absent*. The contract was only ever asserted where the bug cannot appear.

`AutoMigrateStartupTest`, `CliMigrateExitCodeTest`, `MigrationDefaultPathTest`, `MigrationFootgunsTest`, `MigrationV3Test` all still green. (`ParityTestClassTest` errors with "Class Tina4\Test not found" on pristine `v3` here too — pre-existing, unrelated.)

## Upgrade impact — worth a release note

For apps whose table retains `migration_id`, `passed = 0` migrations that were previously skipped in silence now become pending and run. That is the documented intent, and it beats #129 detonating them later — but it surfaces on the **first migrate after upgrading**.

Two things make it land softly, and one that doesn't:
- `migrate()` wraps each file and stops on the first error, so a failure is reported rather than half-applied.
- The runner already skips `CREATE TABLE` / Firebird `ALTER TABLE ADD` that would hit an existing object.
- **But** other non-idempotent DDL is not covered — e.g. a bare `CREATE SEQUENCE` / `CREATE GENERATOR` re-run raises "already exists". A row marked `passed = 0` whose DDL nevertheless committed (easy on Firebird, which auto-commits DDL) will now fail on re-apply, and with `TINA4_AUTO_MIGRATE` on that surfaces at boot. Our own app is in exactly that state — the fix is to reconcile those rows to `passed = 1`, since they did apply, which is the "reconcile the canonical indicator before dropping the legacy column" step #172 part 2 asks for and #129 needs.

Happy to add a `shouldSkip` probe for sequences/generators, or an opt-in reconciliation helper, if you'd like either in scope here.

Refs #172, #129.

## Parity across the four frameworks

Per the parity rule, I checked whether this bug exists in Python, Ruby and Node before shipping PHP alone. **It is PHP-only** — the construct it lives in does not exist in the other three, so there is nothing to port. Evidence:

| framework | canonical key | `passed` column | legacy-prefix fallback | affected |
|---|---|---|---|---|
| **PHP** | `migration_name` | yes | **yes — `SELECT migration_id …` with no `passed` filter** | **yes → this PR** |
| **Python** | `migration_id VARCHAR(500)` (the name; not a 14-char prefix) | yes | `description` fallback, already `WHERE passed = 1` | no |
| **Ruby** | `migration_name` | yes | none | no |
| **Node.js** | `name` | **none** — tracks by row existence | none | n/a |

- `grep -rl migration_id` finds nothing outside PHP and Python, and Python's `migration_id` is its canonical name column, not PHP's legacy 14-char prefix.
- Python's `_get_executed()` filters `WHERE passed = 1` on **both** its lookup and its v2 `description` fallback, so a `passed = 0` row never suppresses a file there.
- Ruby reads applied via `SELECT migration_name … WHERE passed = 1` — one key, no fallback.
- Node's canonical table is `id, name, batch, applied_at` — no `passed` at all, so the contract this PR restores does not exist there to break.

Happy to add the lock-in test to Python and Ruby if you want the "`passed = 0` ⇒ pending" contract pinned in all four rather than only where it can regress — say the word and I'll open those.

### Two things this surfaced for #129

1. **The schema divergence is wider than `passed`'s semantics** — Node has no `passed` column at all and tracks by row existence, which is exactly what the PHP docs used to (wrongly) claim for PHP. Any convergence has to pick one of the two models.
2. **NULL `passed` diverges today.** After this PR, PHP treats `NULL` as *applied* (matching its own upgrade's "existing rows were only ever written when applied"). Python's `WHERE passed = 1` excludes NULL, so it treats NULL as *not applied* and re-runs. Worth settling deliberately as part of convergence rather than by accident.
