### PR TITLE
fix(security): set Secure on session cookies behind a TLS-terminating proxy (#175)

### DIFF
--- a/Tina4/Request.php
+++ b/Tina4/Request.php
@@ -180,8 +180,7 @@ class Request
         // Reconstruct the full absolute URL (scheme://host[:port]/path[?query]).
         // Honours x-forwarded-proto / x-forwarded-host so apps behind a proxy
         // still see the URL the client actually used. Matches Python/Ruby/Node parity.
-        $scheme = $this->headers['x-forwarded-proto']
-            ?? ((($_SERVER['HTTPS'] ?? '') !== '' && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http');
+        $scheme = $this->isSecure() ? 'https' : 'http';
         $host = $this->headers['x-forwarded-host']
             ?? ($this->headers['host'] ?? ($_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? 'localhost')));
         $url = "{$scheme}://{$host}{$this->path}";
@@ -298,6 +297,29 @@ class Request
             }
         }
         return $result;
+    }
+
+    /**
+     * Determines whether the client reached this request over HTTPS.
+     *
+     * Prefers the x-forwarded-proto header so a TLS-terminating proxy (nginx,
+     * HAProxy, an ALB, Cloudflare) reports the scheme the CLIENT used — the SAPI
+     * only sees the plaintext hop behind such a proxy, leaving $_SERVER['HTTPS']
+     * unset. Falls back to $_SERVER['HTTPS'] when no proxy header is present.
+     * A proxy chain may forward a comma-separated list; the first entry is the
+     * client-facing hop.
+     *
+     * @return bool True when the client-facing scheme is https.
+     */
+    public function isSecure(): bool
+    {
+        $forwarded = $this->headers['x-forwarded-proto'] ?? null;
+        if ($forwarded !== null && trim((string)$forwarded) !== '') {
+            $first = trim(explode(',', (string)$forwarded)[0]);
+            return strcasecmp($first, 'https') === 0;
+        }
+
+        return ($_SERVER['HTTPS'] ?? '') !== '' && $_SERVER['HTTPS'] !== 'off';
     }
 
     /**

--- a/Tina4/Router.php
+++ b/Tina4/Router.php
@@ -602,8 +602,9 @@ class Router
             // carried over from ini so the cookie's scope is unchanged.
             $sameSite = getenv('TINA4_SESSION_SAMESITE') ?: 'Lax';
             // SameSite=None requires Secure — browsers reject it otherwise.
-            $nativeSecure = strcasecmp($sameSite, 'None') === 0
-                || (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+            // $request->isSecure() honours x-forwarded-proto, so the flag is set
+            // on a TLS-terminating proxy where $_SERVER['HTTPS'] is never set.
+            $nativeSecure = strcasecmp($sameSite, 'None') === 0 || $request->isSecure();
             $cookieParams = session_get_cookie_params();
             session_set_cookie_params([
                 'lifetime' => $cookieParams['lifetime'],
@@ -642,7 +643,7 @@ class Router
             $ttl = (int)(getenv('TINA4_SESSION_TTL') ?: 3600);
             $sameSite = getenv('TINA4_SESSION_SAMESITE') ?: 'Lax';
             // SameSite=None requires the Secure flag — browsers reject it otherwise
-            $secure = strcasecmp($sameSite, 'None') === 0 || (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+            $secure = strcasecmp($sameSite, 'None') === 0 || $request->isSecure();
 
             if (headers_sent()) {
                 // Built-in server mode: headers are managed via the Response object,

--- a/tests/SessionCookieAttributesTest.php
+++ b/tests/SessionCookieAttributesTest.php
@@ -90,10 +90,17 @@ class SessionCookieAttributesTest extends TestCase
         throw new RuntimeException('php -S did not come up on port ' . $port);
     }
 
-    /** @return string[] Every Set-Cookie header line from a real GET /. */
-    private function fetchSetCookies(): array
+    /**
+     * @param string[] $headers Extra request header lines to send.
+     * @return string[] Every Set-Cookie header line from a real GET /.
+     */
+    private function fetchSetCookies(array $headers = []): array
     {
-        $ctx = stream_context_create(['http' => ['method' => 'GET', 'ignore_errors' => true]]);
+        $http = ['method' => 'GET', 'ignore_errors' => true];
+        if ($headers !== []) {
+            $http['header'] = implode("\r\n", $headers);
+        }
+        $ctx = stream_context_create(['http' => $http]);
         $body = @file_get_contents('http://127.0.0.1:' . self::$server[1] . '/', false, $ctx);
         $this->assertNotFalse($body, 'the clean-room app must respond');
         $cookies = [];
@@ -163,6 +170,67 @@ class SessionCookieAttributesTest extends TestCase
             '/;\s*Secure/i',
             $native,
             'Secure must not be set on plain HTTP with the default SameSite=Lax — ' . $native
+        );
+    }
+
+    /**
+     * Security regression for tina4stack/tina4-php#175.
+     *
+     * TLS terminated at a proxy means the SAPI only ever sees the plaintext hop,
+     * so $_SERVER['HTTPS'] is unset and both cookies went out without Secure on a
+     * genuinely HTTPS request — leaving them sendable over plaintext, where an
+     * active network attacker can strip TLS and capture them. Request::isSecure()
+     * reads x-forwarded-proto, which Request already trusted for $request->url.
+     *
+     * @return string[] Both Set-Cookie lines behind a simulated TLS proxy.
+     */
+    private function fetchSetCookiesBehindTlsProxy(): array
+    {
+        return $this->fetchSetCookies(['X-Forwarded-Proto: https']);
+    }
+
+    public function testCookiesAreSecureBehindTlsTerminatingProxy(): void
+    {
+        $cookies = $this->fetchSetCookiesBehindTlsProxy();
+        foreach (['PHPSESSID', 'tina4_session'] as $name) {
+            $cookie = $this->cookieNamed($cookies, $name);
+            $this->assertNotNull($cookie, "{$name} must be emitted");
+            $this->assertMatchesRegularExpression(
+                '/;\s*Secure/i',
+                $cookie,
+                "{$name} must carry Secure when x-forwarded-proto says the client used https, "
+                    . 'otherwise it can be sent over plaintext and stripped — ' . $cookie
+            );
+        }
+    }
+
+    public function testForwardedProtoHttpDoesNotForceSecure(): void
+    {
+        // A proxy that terminates plain HTTP must not produce a Secure cookie —
+        // that would make the cookie undeliverable to the client.
+        $cookies = $this->fetchSetCookies(['X-Forwarded-Proto: http']);
+        foreach (['PHPSESSID', 'tina4_session'] as $name) {
+            $cookie = $this->cookieNamed($cookies, $name);
+            $this->assertNotNull($cookie);
+            $this->assertDoesNotMatchRegularExpression(
+                '/;\s*Secure/i',
+                $cookie,
+                "{$name} must not be Secure when the client-facing scheme is http — " . $cookie
+            );
+        }
+    }
+
+    public function testForwardedProtoChainUsesClientFacingHop(): void
+    {
+        // Multi-proxy chains forward a comma-separated list; the FIRST entry is
+        // the scheme the client actually used.
+        $cookies = $this->fetchSetCookies(['X-Forwarded-Proto: https, http']);
+        $native = $this->cookieNamed($cookies, 'PHPSESSID');
+        $this->assertNotNull($native);
+        $this->assertMatchesRegularExpression(
+            '/;\s*Secure/i',
+            $native,
+            'the client-facing hop (https) decides the flag, not a later internal hop — ' . $native
         );
     }
 }


### PR DESCRIPTION
Fixes #175.

Both session cookies computed `Secure` from `$_SERVER['HTTPS']` alone, which is never set when TLS terminates at a proxy — so on a typical HTTPS deployment neither cookie got `Secure` and both stayed sendable over plaintext, where an active attacker can strip TLS and capture them.

`Request` already trusted `x-forwarded-proto` to build `$request->url`, so the framework was reporting `https://…` for the very request whose cookies concluded they were on plain HTTP. This lifts that existing detection into one place and points all three call sites at it.

## Changes

**`Request::isSecure(): bool`** — new public method. Prefers `x-forwarded-proto` (first hop of a comma-separated chain), falls back to `$_SERVER['HTTPS']`. `Request`'s URL builder now calls it instead of inlining the check, so scheme detection lives in exactly one place and can't drift again — the DRY rule in `CLAUDE.md`.

**`Router::dispatch()`** — both cookie sites (`PHPSESSID` from #174, and `tina4_session`) now use `$request->isSecure()`. The `SameSite=None ⇒ Secure` rule is unchanged.

It's also useful on its own: `if ($request->isSecure())` is a reasonable thing for an app to want, and there was no supported way to ask.

## Tests

Four new cases in the existing `SessionCookieAttributesTest` harness, which boots a real `php -S` server against a clean-room app and reads actual `Set-Cookie` headers off the wire. No mocks — a params-level assertion would pass even if something later overrode them.

- `testCookiesAreSecureBehindTlsTerminatingProxy` — `X-Forwarded-Proto: https` ⇒ both cookies carry `Secure`
- `testForwardedProtoHttpDoesNotForceSecure` — `X-Forwarded-Proto: http` ⇒ neither does
- `testForwardedProtoChainUsesClientFacingHop` — `https, http` ⇒ the client-facing hop decides
- (plus the existing plain-HTTP and attribute-symmetry cases)

**Negative control** — with the source fix reverted and the tests kept, exactly the two `Secure`-expecting tests fail:

```
1) SessionCookieAttributesTest::testCookiesAreSecureBehindTlsTerminatingProxy
2) SessionCookieAttributesTest::testForwardedProtoChainUsesClientFacingHop
Tests: 7, Assertions: 27, Failures: 2.
```

With the fix: `OK (7 tests, 29 assertions)`. `testForwardedProtoHttpDoesNotForceSecure` passes either way by design — it guards against over-correcting into an undeliverable cookie.

## The trust question — worth your call

`X-Forwarded-Proto` is client-spoofable when the app is directly reachable, and Tina4 has no trusted-proxy concept. I went with honouring it because:

- the failure mode is self-limiting — a spoofed `https` only makes a cookie **more** restrictive (`Secure` ⇒ not sent over HTTP). It can't downgrade anything or expose data;
- `Request` already trusts the same header for URL construction, so this is consistent with existing behaviour rather than a new trust assumption.

If you'd rather gate it behind `TINA4_TRUSTED_PROXY`, say so and I'll rework — though that reintroduces the silent-misconfiguration problem for anyone who doesn't set it.

## Parity — needs a maintainer decision, not in this PR

Per the parity rule I checked the other three, and they are **not** currently equivalent. Each does something different, and two are worse than PHP was:

| | `Secure` | `TINA4_SESSION_SAMESITE` |
|---|---|---|
| PHP (before this PR) | `$_SERVER['HTTPS']` only | honoured |
| Python (`core/server.py:1775`) | **never emitted** | honoured |
| Ruby (`lib/tina4/rack_app.rb:274`) | **never emitted** | **ignored — hardcoded `Lax`** |
| Node (`core/src/session.ts:604`) | opt-in `TINA4_SESSION_SECURE` only | honoured |

All four already honour `x-forwarded-proto` in their `Request`, so the same helper-and-reuse shape ports cleanly. But this isn't one mechanical port: Python and Ruby need `Secure` support built (not just rewired), Node's documented `TINA4_SESSION_SECURE=false` default would have to change behaviour, and Ruby ignoring `TINA4_SESSION_SAMESITE` looks like a separate bug worth its own issue.

I didn't want to make those calls unilaterally or bundle four behaviour changes into a security fix. Happy to open the three follow-up PRs (and the Ruby SameSite issue) — just tell me which shape you want.

## ⚠️ These tests do not currently run in CI — nor did #174's

While verifying I found that `SessionCookieAttributesTest` **is not in the CI suite**, so the regression test added with the #174 fix has never gated anything, and neither will the cases in this PR.

`phpunit.xml` defines its testsuites as an explicit `<file>` list (106 files, no `<directory>` glob), and `.github/workflows/test.yml:242` runs `vendor/bin/phpunit` with no path argument — so only those 106 files load. `composer test` runs `phpunit tests`, whose path argument overrides the config and picks up everything, which is why this passes locally but is invisible to CI.

Straight from PHPUnit's own enumeration (`--list-tests`), not inferred:

```
$ vendor/bin/phpunit --list-tests | grep -c 'SessionCookieAttributes'
0
```

186 `TestCase` classes exist under `tests/`; CI runs 106. **89 never run**, including `McpSecurityTest`, `MiddlewareAuthBypassTest`, `WebSocketAuthTest`, `RouterAuthSourcesTest`, `DatabaseSessionHandlerInjectionTest`, `SecureByDefaultTest`, and `SessionCookieAttributesTest`.

Adding one line to `phpunit.xml` fixes it for this file:

```xml
<file>tests/SessionCookieAttributesTest.php</file>
```

I've deliberately **not** included that here — wiring in 89 files at once will surface unrelated failures (`ParityTestClassTest` fatals at collection, see below) and that's a call for you, not something to smuggle into a security fix. Say the word and I'll add just this file, or open a separate PR/issue for the wider gap.

## Notes

- No changes to cookie name, storage path, TTL, or the `SameSite=None` rule.
- `composer.lock` deliberately untouched.
- Unrelated pre-existing breakage: `tests/ParityTestClassTest.php` fatals at collection with `Class "Tina4\Test" not found` on pristine `v3` — that class doesn't exist anywhere in the repo. CI never loads it (it's one of the 89), so it's invisible there, but it makes a bare `composer test` impossible. Not touched here.
- I could not run the full 2,891-test CI suite locally — it needs the provisioned services (PostgreSQL/Redis/Mongo/RabbitMQ/Kafka) this machine doesn't have. I ran the affected area instead: `RequestV3Test`, `RequestLoggingTest`, `RouterSessionStartTest`, `SessionV3Test`, `SessionCookieAttributesTest` → **OK (88 tests, 185 assertions)**. CI is the authority on the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
