### PR TITLE
Fix pdo_firebird rollback (silent no-op) + parity-test teardown hang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -340,17 +340,17 @@ jobs:
       # job (naming the file) rather than hanging the runner for hours.
       - name: Run Firebird tests (native ext-interbase)
         run: |
-          # NATIVE ext-interbase tests only. The Pdo*Fallback / PdoFirebirdAdapter
-          # tests exercise the pdo_firebird driver, which is NOT built here
-          # (native-only job) — with native present but pdo_firebird absent they
-          # do not skip cleanly (PdoFallbackParityTest even hangs on native x86).
-          # They keep their coverage on macOS/local dev where pdo_firebird exists.
+          # Native ext-interbase tests PLUS the pdo_firebird tests. pdo_firebird is
+          # present here (the setup-php PHP 8.2 image bundles it), so both drivers
+          # are available and the native-vs-pdo parity + PDO-adapter tests run for
+          # real. (If a future runner drops pdo_firebird those tests skip cleanly.)
           files="tests/FirebirdCharsetTest.php tests/FirebirdNullParamBindingTest.php \
             tests/FirebirdOrmCountTest.php tests/FirebirdOrmWriteTest.php \
             tests/FirebirdReconnectTest.php tests/FirebirdUrlTest.php \
             tests/FirebirdWriteVisibilityTest.php tests/MigrationV3Test.php \
             tests/DatabaseDriversTest.php tests/BooleanParamBindingTest.php \
-            tests/SchemaQualifiedTest.php"
+            tests/SchemaQualifiedTest.php tests/PdoFirebirdAdapterTest.php \
+            tests/PdoFallbackFactoryTest.php tests/PdoFallbackParityTest.php"
           failed=""
           for f in $files; do
             echo "::group::$f"

--- a/Tina4/Database/PdoAdapterTrait.php
+++ b/Tina4/Database/PdoAdapterTrait.php
@@ -362,9 +362,30 @@ trait PdoAdapterTrait
         return $this->lastId;
     }
 
+    /**
+     * Whether startTransaction()/commit()/rollback() must toggle
+     * PDO::ATTR_AUTOCOMMIT around an explicit transaction.
+     *
+     * Default false — sqlite/pgsql report inTransaction() honestly, so the
+     * beginTransaction() guard below is enough. ONLY pdo_firebird needs this:
+     * it reports inTransaction()===true even in autocommit mode, so the guard
+     * would skip beginTransaction() and no real rollback boundary would ever be
+     * established (an INSERT auto-commits immediately and rollback() cannot undo
+     * it). Turning autocommit OFF clears that phantom state so a genuine
+     * transaction begins; it is restored to ON on commit()/rollback() so
+     * standalone reads/writes keep working. Overridden in PdoFirebirdAdapter.
+     */
+    protected function transactionsNeedAutocommitToggle(): bool
+    {
+        return false;
+    }
+
     public function startTransaction(): void
     {
         $this->ensureOpen();
+        if ($this->transactionsNeedAutocommitToggle()) {
+            $this->pdo->setAttribute(\PDO::ATTR_AUTOCOMMIT, false);
+        }
         if (!$this->pdo->inTransaction()) {
             $this->pdo->beginTransaction();
         }
@@ -375,6 +396,9 @@ trait PdoAdapterTrait
         $this->ensureOpen();
         if ($this->pdo->inTransaction()) {
             $this->pdo->commit();
+        }
+        if ($this->transactionsNeedAutocommitToggle()) {
+            $this->pdo->setAttribute(\PDO::ATTR_AUTOCOMMIT, true);
         }
     }
 
@@ -389,6 +413,10 @@ trait PdoAdapterTrait
             // Rollback may fail if no transaction is active — record, never raise
             // (parity with the native adapters).
             $this->lastError = $e->getMessage();
+        } finally {
+            if ($this->transactionsNeedAutocommitToggle()) {
+                $this->pdo->setAttribute(\PDO::ATTR_AUTOCOMMIT, true);
+            }
         }
     }
 

--- a/Tina4/Database/PdoFirebirdAdapter.php
+++ b/Tina4/Database/PdoFirebirdAdapter.php
@@ -99,6 +99,17 @@ class PdoFirebirdAdapter implements DatabaseAdapter
         return ' RETURNING *';
     }
 
+    /**
+     * pdo_firebird reports PDO::inTransaction()===true even in autocommit mode,
+     * so startTransaction() must turn autocommit OFF to establish a real
+     * transaction boundary (otherwise every statement auto-commits and
+     * rollback() cannot undo it). commit()/rollback() restore autocommit.
+     */
+    protected function transactionsNeedAutocommitToggle(): bool
+    {
+        return true;
+    }
+
     /** Firebird pads/returns identifiers with trailing spaces — trim like native. */
     protected function normalizeReturnedId(mixed $value): int|string
     {

--- a/tests/PdoFallbackParityTest.php
+++ b/tests/PdoFallbackParityTest.php
@@ -347,12 +347,16 @@ class PdoFallbackParityTest extends TestCase
         $this->assertSame(42, $pdoRow['QTY']);
         $this->assertSame(self::BLOB, $pdoRow['DATA'] ?? $pdoRow['data'] ?? null);
 
+        // Close the PDO reader BEFORE the native DROP. pdo_firebird holds an idle
+        // read transaction after a SELECT, and Firebird DDL (DROP TABLE) needs
+        // exclusive metadata access — with the reader still open the DROP blocks
+        // forever (WAIT). Releasing the reader first lets the cleanup proceed.
+        $pdo->close();
         try {
             $native->execute('DROP TABLE T4_PDO_PARITY');
         } catch (\Throwable) {
         }
         $native->close();
-        $pdo->close();
     }
 
     public function testFirebirdExecuteRaisesParity(): void


### PR DESCRIPTION
## What

Two real bugs in the **pdo_firebird fallback adapter**, both reproduced live against a real Firebird 5.0.2. They surface whenever **both** native `ext-interbase` and `pdo_firebird` are present — which is the case in the `firebird` CI job (setup-php's PHP 8.2 bundles pdo_firebird). Not an x86-only quirk as first suspected; my earlier container simply lacked pdo_firebird so these tests skipped.

### 1. `rollback()` was a silent no-op (data-integrity bug)
pdo_firebird reports `PDO::inTransaction() === true` even in autocommit mode, so the shared trait's `if (!inTransaction()) beginTransaction()` guard **never began a real transaction**. Every INSERT auto-committed immediately, and `rollback()` had nothing to undo — the row survived (`PdoFirebirdAdapterTest::testTransactionCommitAndRollback`: "1 is identical to 0").

**Fix:** a Firebird-only `transactionsNeedAutocommitToggle()` hook in `PdoAdapterTrait` turns `PDO::ATTR_AUTOCOMMIT` off in `startTransaction()` (establishing a genuine boundary) and restores it on `commit()`/`rollback()`. sqlite/pgsql keep the default `false` — zero behaviour change for them.

### 2. `PdoFallbackParityTest` hung at teardown
pdo_firebird holds an idle read transaction after a SELECT, so the native cleanup `DROP TABLE` (Firebird DDL needs exclusive metadata access) blocked forever (`WAIT`). **Fix:** close the PDO reader before the native DROP.

Both PDO-Firebird test files are re-included in the native `firebird` CI job (the earlier exclusion assumed pdo_firebird was absent — it isn't).

## Verified (no-mock, real FB5.0.2)
- `PdoFirebirdAdapterTest` + `PdoFallbackParityTest` + `PdoFallbackFactoryTest`: **21 / 0F**, no hang (both drivers present).
- Full macOS suite (shared-trait regression check): **3990 / 0F / 94 skip** — identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)