### PR TITLE
docs: add Codex skill entrypoints

### DIFF
--- a/.agents/skills/tina4-developer-php/SKILL.md
+++ b/.agents/skills/tina4-developer-php/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-developer-php
+description: Tina4 PHP application-development instructions.
+---
+
+# Tina4 PHP Developer
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-developer-php/SKILL.md`.

--- a/.agents/skills/tina4-js/SKILL.md
+++ b/.agents/skills/tina4-js/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-js
+description: Tina4-js frontend instructions for Tina4 projects.
+---
+
+# Tina4-js
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-js/SKILL.md`.

--- a/.agents/skills/tina4-maintainer/SKILL.md
+++ b/.agents/skills/tina4-maintainer/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-maintainer
+description: Tina4 cross-language maintenance instructions.
+---
+
+# Tina4 Maintainer
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-maintainer/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Lightweight, zero-dependency PHP web framework. Docs: https://tina4.com
 
+## AI Skills
+
+Codex discovers the project skills in `.agents/skills`; each is a tracked entrypoint to the canonical `.claude/skills` instructions also used by Claude. Use the maintainer, PHP developer, and Tina4-js skills that apply to the task.
+
 ## CLI Commands
 
 ```bash


### PR DESCRIPTION
Expose the existing tracked Claude skills through Codex-native .agents/skills entrypoints without duplicating content.