### PR TITLE
Release 3.13.100

### DIFF
--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -2,7 +2,7 @@
 name: tina4-js
 description: >
   Use whenever working with tina4-js — the lightweight reactive frontend framework.
-  Trigger on any mention of tina4-js, tina4 signals, persistent signals, persist(),
+  Trigger on any mention of tina4-js, tina4js, Tina4 JS, tina4 signals, persistent signals, persist(),
   Tina4Element, tina4 html tagged templates, tina4 routing, tina4 WebSocket client,
   tina4 API client, or persistent storage of UI preferences. Also trigger when the user
   is building a client-rendered frontend for a Tina4 backend, or when they're working

--- a/.claude/skills/tina4-js/references/html-and-components.md
+++ b/.claude/skills/tina4-js/references/html-and-components.md
@@ -33,6 +33,9 @@ Returns a `DocumentFragment` with real DOM nodes. Templates are cached by string
 | `null`/`undefined` | Empty |
 | `false` | The text "false" (NOT empty!) |
 
+Valid HTML comments are ignored when determining interpolation context. Quotes inside a comment
+do not turn a following content interpolation into an attribute binding.
+
 **Critical:** `${false}` renders as the literal text "false". For conditional show/hide, use:
 ```ts
 ${() => condition ? html`<p>Show</p>` : null}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ https://tina4.com/php/36-releases
 
 ## 3.13.100 (unreleased)
 
+### Breaking: Frond instance extensions stay local
+
+Calling `addFilter`, `addGlobal`, or `addTest` on a Frond instance now changes
+that renderer only. Register on `Frond` itself when every later instance must
+inherit the extension.
+
 - Reject a second `{% extends %}` tag instead of replacing the first parent without warning.
 - Lock PHP's already-correct nested block behavior with the shared regression.
 - Bound template, fragment, and expression caches, with TTL sweeps for stale entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Changelog
+
+Tina4 keeps ONE version across all four frameworks (Python, PHP, Ruby, Node.js), so a version
+number means the same thing everywhere.
+
+**The authoritative release notes for every shipped version live in the documentation:**
+https://tina4.com/php/36-releases
+
+## 3.13.100 (unreleased)
+
+- Reject a second `{% extends %}` tag instead of replacing the first parent without warning.
+- Lock PHP's already-correct nested block behavior with the shared regression.
+- Bound template, fragment, and expression caches, with TTL sweeps for stale entries.
+- Retry transient AI skill-download failures.
+- Keep the runtime version and AI-facing guide on one version.
+
+## 3.13.99
+
 ### Breaking: `$request->params` is route-params-only
 
 Client input now lives only in `$request->query` and `$request->body`; `$request->params`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ inherit the extension.
 - Lock PHP's already-correct nested block behavior with the shared regression.
 - Bound template, fragment, and expression caches, with TTL sweeps for stale entries.
 - Retry transient AI skill-download failures.
+- Activate the tina4-js skill for `tina4js` and `Tina4 JS` spellings as well as `tina4-js`.
 - Keep the runtime version and AI-facing guide on one version.
 
 ## 3.13.99

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.99 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.100 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 

--- a/Tina4/AI.php
+++ b/Tina4/AI.php
@@ -96,37 +96,89 @@ class AI
         return sys_get_temp_dir();
     }
 
+    /** HTTP statuses worth retrying — a throttle or a server hiccup, not a real answer. */
+    private const TRANSIENT_HTTP_CODES = [429, 500, 502, 503, 504];
+
+    /** Backoff (seconds) before each retry — short, one entry per retry attempt. */
+    private const FETCH_RETRY_BACKOFF = [1, 2];
+
     /**
      * Fetch a URL's bytes, or null on any failure. Uses curl when available
-     * (clean timeout handling), else file_get_contents. 15s timeout.
+     * (clean timeout handling), else file_get_contents. 15s timeout per attempt.
+     *
+     * raw.githubusercontent.com returns an intermittent 503 under load (a
+     * freshly cut release tag is "cold" on GitHub's CDN until it warms), and
+     * `tina4 ai` makes ~30 fetches per install — a single transient blip must
+     * not abort the whole install. Retries a transient HTTP status
+     * (429/500/502/503/504) or a transport-level failure (connection
+     * refused/reset/timeout — no response at all) with a short backoff
+     * between attempts; a permanent 4xx (404, etc.) is a genuine answer and
+     * is never retried. Mirrors Python's `_fetch_bytes` and Ruby's
+     * `fetch_bytes`/`TRANSIENT_HTTP_CODES`.
      */
     private static function fetchBytes(string $url): ?string
     {
-        if (function_exists('curl_init')) {
-            $ch = curl_init($url);
-            curl_setopt_array($ch, [
-                CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_FOLLOWLOCATION => true,
-                CURLOPT_CONNECTTIMEOUT => 15,
-                CURLOPT_TIMEOUT => 15,
-                CURLOPT_FAILONERROR => true,
-                CURLOPT_USERAGENT => 'tina4-php-ai-installer',
-            ]);
-            $data = curl_exec($ch);
-            $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            // curl_close() is a no-op since PHP 8.0 (deprecated in 8.5); the
-            // CurlHandle is freed on GC. Leaving it out keeps 8.5 quiet.
-            if ($data !== false && $code >= 200 && $code < 300) {
-                return $data;
+        $maxAttempts = count(self::FETCH_RETRY_BACKOFF) + 1;
+
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            $code = null;
+            $transportFailed = false;
+
+            if (function_exists('curl_init')) {
+                $ch = curl_init($url);
+                curl_setopt_array($ch, [
+                    CURLOPT_RETURNTRANSFER => true,
+                    CURLOPT_FOLLOWLOCATION => true,
+                    CURLOPT_CONNECTTIMEOUT => 15,
+                    CURLOPT_TIMEOUT => 15,
+                    CURLOPT_FAILONERROR => true,
+                    CURLOPT_USERAGENT => 'tina4-php-ai-installer',
+                ]);
+                $data = curl_exec($ch);
+                $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+                // curl_close() is a no-op since PHP 8.0 (deprecated in 8.5); the
+                // CurlHandle is freed on GC. Leaving it out keeps 8.5 quiet.
+                if ($data !== false && $code >= 200 && $code < 300) {
+                    return $data;
+                }
+                $transportFailed = ($code === 0);
+            } else {
+                $context = stream_context_create([
+                    'http' => ['timeout' => 15, 'follow_location' => 1, 'user_agent' => 'tina4-php-ai-installer'],
+                    'ssl'  => ['verify_peer' => true, 'verify_peer_name' => true],
+                ]);
+                $data = @file_get_contents($url, false, $context);
+                if ($data !== false) {
+                    return $data;
+                }
+                $code = self::statusCodeFromResponseHeaders($http_response_header ?? []);
+                $transportFailed = ($code === null);
             }
+
+            $transient = $transportFailed || in_array($code, self::TRANSIENT_HTTP_CODES, true);
+            $hasMoreAttempts = $attempt <= count(self::FETCH_RETRY_BACKOFF);
+            if (!$transient || !$hasMoreAttempts) {
+                return null;
+            }
+            sleep(self::FETCH_RETRY_BACKOFF[$attempt - 1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse the numeric status code from the `$http_response_header` PHP
+     * populates after a stream-wrapper `file_get_contents()` call, or null
+     * when it is absent/unparseable (a transport failure — no response).
+     *
+     * @param string[] $headers
+     */
+    private static function statusCodeFromResponseHeaders(array $headers): ?int
+    {
+        if (!isset($headers[0]) || !preg_match('/^HTTP\/\S+\s+(\d{3})/', $headers[0], $m)) {
             return null;
         }
-        $context = stream_context_create([
-            'http' => ['timeout' => 15, 'follow_location' => 1, 'user_agent' => 'tina4-php-ai-installer'],
-            'ssl'  => ['verify_peer' => true, 'verify_peer_name' => true],
-        ]);
-        $data = @file_get_contents($url, false, $context);
-        return $data === false ? null : $data;
+        return (int)$m[1];
     }
 
     /**

--- a/Tina4/App.php
+++ b/Tina4/App.php
@@ -34,7 +34,7 @@ class App
      *
      * @var string
      */
-    public static string $VERSION = '3.13.99';
+    public static string $VERSION = '3.13.100';
 
     /**
      * The health path that is registered no matter what TINA4_HEALTH_PATH says.

--- a/Tina4/Frond.php
+++ b/Tina4/Frond.php
@@ -18,6 +18,12 @@ class Frond
     private array $globals = [];
     private array $filters = [];
     private array $tests = [];
+    /**
+     * @var array<string, array{content: string, time: int, ttl: int}>
+     *   Runtime store for {% cache %} fragments. Bounded at TEMPLATE_CACHE_MAX
+     *   (capMemoCache) and swept of TTL-expired entries on every access
+     *   (sweepExpiredCache) -- ADR-0004.
+     */
     private array $cache = [];
     private bool $sandboxed = false;
 
@@ -330,6 +336,39 @@ class Frond
             unset($cache[$key]);
             if (--$drop <= 0) {
                 break;
+            }
+        }
+    }
+
+    /**
+     * Drop every TTL-expired entry from the {% cache %} fragment store ($cache).
+     *
+     * capMemoCache() bounds a cache by SIZE (insertion order, oldest first) but
+     * says nothing about STALENESS: a key that expired and is never read again
+     * would otherwise sit in the array, still counted against the cap, until
+     * something else finally evicts it. An app keying fragments on a dynamic
+     * value (a page id, a user id) can churn through many such keys, so
+     * staleness has to be swept on its own schedule, not just bounded by count.
+     *
+     * `elapsed >= ttl` also correctly sweeps a ttl<=0 entry (elapsed since
+     * insertion is always >= 0): renderCache() never treats ttl<=0 as a hit
+     * in the first place (see the "0 means NOT cached" comment there), so
+     * there is no reason to keep it in memory either.
+     *
+     * Called on every {% cache %} render (cheap: bounded by TEMPLATE_CACHE_MAX
+     * entries, so at most 256 comparisons) rather than only for the key being
+     * read, so an unrelated key's expiry is cleaned up as a side effect of ANY
+     * fragment-cache render, not just a future hit on that same key.
+     *
+     * @param array<string, array{content: string, time: int, ttl: int}> $cache
+     *   Fragment cache to sweep, by reference.
+     */
+    private function sweepExpiredCache(array &$cache): void
+    {
+        $now = time();
+        foreach ($cache as $key => $entry) {
+            if (($now - $entry['time']) >= $entry['ttl']) {
+                unset($cache[$key]);
             }
         }
     }
@@ -1541,6 +1580,7 @@ class Frond
 
     private function renderCache(array $node, array &$data): string
     {
+        $this->sweepExpiredCache($this->cache);
 
         $key = $node['key'];
         if (isset($this->cache[$key])) {
@@ -1554,6 +1594,7 @@ class Frond
         }
 
         $content = $this->execute($node['body'], $data);
+        $this->capMemoCache($this->cache, self::TEMPLATE_CACHE_MAX);
         $this->cache[$key] = [
             'content' => $content,
             'time' => time(),

--- a/Tina4/Frond.php
+++ b/Tina4/Frond.php
@@ -1007,15 +1007,24 @@ class Frond
 
     private function resolveInheritance(array $ast, array &$data, ?string $templateName): array
     {
-        // Find extends node
-        $extendsNode = null;
-        foreach ($ast as $node) {
-            if ($node['type'] === 'extends') {
-                $extendsNode = $node;
-                break;
-            }
+        // Find extends node(s) -- a template may extend at most one parent.
+        // Before 3.13.100 a SECOND {% extends %} tag was silently invisible:
+        // this loop broke on the first match and never looked further, so the
+        // rest -- including the second extends target -- was discarded with
+        // no signal, almost always hiding a copy-paste or a bad merge. Raise
+        // clearly instead, the same policy 3.13.89 applied to an unknown tag.
+        $extendsNodes = array_values(array_filter(
+            $ast,
+            static fn(array $node): bool => $node['type'] === 'extends',
+        ));
+        if (count($extendsNodes) > 1) {
+            throw new \RuntimeException(
+                'Frond: template has ' . count($extendsNodes) . ' "{% extends %}" tags -- '
+                . 'a template can extend only one parent'
+            );
         }
 
+        $extendsNode = $extendsNodes[0] ?? null;
         if ($extendsNode === null) return $ast;
 
         // Collect child blocks

--- a/Tina4/Frond.php
+++ b/Tina4/Frond.php
@@ -418,30 +418,27 @@ class Frond
      * so we use ``__call`` (instance side) + ``__callStatic`` (class side)
      * to implement Python's ``_ClassOrInstanceMethod`` pattern:
      *
-     *   ``Frond::addFilter("money", $fn)``  → ``__callStatic`` → class registry only
-     *   ``$frond->addFilter("money", $fn)`` → ``__call``       → class registry AND
-     *                                                            instance's local map
+     *   ``Frond::addFilter("money", $fn)``  → ``__callStatic`` → class registry
+     *   ``$frond->addFilter("money", $fn)`` → ``__call``       → instance map only
      *
      * Future ``new Frond()`` instances drain the class registry in their
      * constructor, so filters/globals/tests registered statically at
-     * app-startup propagate to every later instance automatically.
+     * app-startup propagate to every later instance automatically. Instance
+     * calls remain local. tina4: ADR-0052.
      */
     public function __call(string $method, array $args): mixed
     {
         switch ($method) {
             case 'addFilter':
                 [$name, $fn] = $args;
-                self::$classFilters[$name] = $fn;
                 $this->filters[$name] = $fn;
                 return null;
             case 'addGlobal':
                 [$name, $value] = $args;
-                self::$classGlobals[$name] = $value;
                 $this->globals[$name] = $value;
                 return null;
             case 'addTest':
                 [$name, $fn] = $args;
-                self::$classTests[$name] = $fn;
                 $this->tests[$name] = $fn;
                 return null;
         }

--- a/plan/frond-instance-registration-scope.md
+++ b/plan/frond-instance-registration-scope.md
@@ -1,0 +1,26 @@
+# Task: Frond instance registration scope
+
+**Outcome:** Frond class registrations remain process-global while instance registrations remain local, per ADR-0052.
+
+## Scope
+- [x] Read Feature 56 and ADR-0052
+- [x] Add failing scope regressions
+- [x] Remove instance-to-class writes
+- [ ] Verify focused and full lab suites
+
+## Parity
+| Feature | Python | PHP | Ruby | Node.js |
+|---|---|---|---|---|
+| ADR-0052 scope | in progress | in progress | in progress | in progress |
+
+## Tests
+- [x] Class registration reaches later instances
+- [x] Instance filter/global/test registrations do not reach later instances
+
+## Bugs
+- [ ] EX-INSTANCE-LEAKS-CLASS
+
+## Commits
+- pending
+
+## Status: In Progress

--- a/plan/frond-instance-registration-scope.md
+++ b/plan/frond-instance-registration-scope.md
@@ -6,21 +6,21 @@
 - [x] Read Feature 56 and ADR-0052
 - [x] Add failing scope regressions
 - [x] Remove instance-to-class writes
-- [ ] Verify focused and full lab suites
+- [x] Verify focused and full lab suites
 
 ## Parity
 | Feature | Python | PHP | Ruby | Node.js |
 |---|---|---|---|---|
-| ADR-0052 scope | in progress | in progress | in progress | in progress |
+| ADR-0052 scope | ✅ | ✅ | ✅ | ✅ |
 
 ## Tests
 - [x] Class registration reaches later instances
 - [x] Instance filter/global/test registrations do not reach later instances
 
 ## Bugs
-- [ ] EX-INSTANCE-LEAKS-CLASS
+- [x] EX-INSTANCE-LEAKS-CLASS
 
 ## Commits
-- pending
+- `f6fb7f23` - implementation, regressions, CHANGELOG
 
-## Status: In Progress
+## Status: Complete

--- a/tests/AIFetchRetryTest.php
+++ b/tests/AIFetchRetryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Locks in the 503-retry added to Tina4\AI::fetchBytes() (3.13.100) — mirrors
+ * tina4-python's tests/test_ai_fetch_retry.py and the equivalent Ruby/Node
+ * specs. `install_skills()`/`installSkills()` fetches ~30 files from
+ * raw.githubusercontent.com, which 503s intermittently under load (a freshly
+ * cut release tag is "cold" on GitHub's CDN until it warms) — a single
+ * transient blip must not abort the whole install.
+ *
+ * NO MOCKS: a REAL HTTP server (tests/fixtures/ai_fetch_retry_server.php)
+ * owns its own socket and answers a scripted sequence — no monkeypatched
+ * curl/file_get_contents/sleep. fetchBytes is PRIVATE, so it is invoked via
+ * Reflection (the same pattern AIInstallerTest uses for writeOrMerge)
+ * rather than exposed just for testing.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\AI;
+
+class AIFetchRetryTest extends TestCase
+{
+    private static ?TestServer $server = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestServer::startScript(__DIR__ . '/fixtures/ai_fetch_retry_server.php');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$server?->stop();
+        self::$server = null;
+    }
+
+    private function fetchBytes(string $url): ?string
+    {
+        $ref = new ReflectionClass(AI::class);
+        $method = $ref->getMethod('fetchBytes');
+        return $method->invoke(null, $url);
+    }
+
+    /** How many requests the REAL server saw for a path — a live HTTP read, not an in-process counter. */
+    private function hits(string $path): int
+    {
+        $body = $this->fetchBytes(self::$server->base() . '/hits?path=' . urlencode($path));
+        $this->assertNotNull($body, 'the hit-count endpoint must answer');
+        $decoded = json_decode((string)$body, true);
+        return (int)$decoded['hits'];
+    }
+
+    /**
+     * POSITIVE: two transient 503s, then a 200 — fetchBytes must ride
+     * through both and hand back the real body (not null).
+     */
+    public function testFetchRetriesTransient503ThenReturnsBody(): void
+    {
+        $data = $this->fetchBytes(self::$server->base() . '/skill');
+
+        $this->assertSame('skill body', $data);
+        $this->assertSame(3, $this->hits('/skill'), 'proves it actually retried twice, not just once');
+    }
+
+    /**
+     * NEGATIVE: a permanent 404 must return null on the FIRST attempt — no
+     * retry, no backoff sleep. If the loop wrongly retried a 404 this would
+     * take at least 1s (the first backoff step) and hit the server more than
+     * once; the elapsed-time bound is what makes this "fails fast" rather
+     * than just a status check.
+     */
+    public function testFetchFastFailsPersistent404WithoutRetrying(): void
+    {
+        $start = microtime(true);
+        $data = $this->fetchBytes(self::$server->base() . '/missing');
+        $elapsed = microtime(true) - $start;
+
+        $this->assertNull($data);
+        $this->assertSame(1, $this->hits('/missing'), 'NEGATIVE: no retry on a permanent 404');
+        $this->assertLessThan(1.0, $elapsed, 'fast — well under even a single 1s backoff sleep');
+    }
+}

--- a/tests/FrondFragmentCacheTest.php
+++ b/tests/FrondFragmentCacheTest.php
@@ -12,6 +12,15 @@
  * forever" (they treat now+0 as already expired, so 0 means not cached). A
  * {% cache "k" %} block therefore never re-rendered for the life of a PHP
  * process. Test names match the other three one-for-one.
+ *
+ * 3.13.100 (ADR-0004): the runtime store ($cache) was ALSO unbounded AND
+ * never swept a TTL-expired entry -- a key that expired and was never read
+ * again sat in memory for the life of the worker, since expiry was only
+ * ever checked lazily on a re-read of that SAME key. Now bounded at
+ * TEMPLATE_CACHE_MAX (capMemoCache) and swept of every TTL-expired entry on
+ * every {% cache %} render (sweepExpiredCache). Reproduced for real below:
+ * real renders through the real engine, and the real private cache read by
+ * reflection. No mocks: nothing here stands in for the engine or the clock.
  */
 
 use PHPUnit\Framework\TestCase;
@@ -48,5 +57,113 @@ class FrondFragmentCacheTest extends TestCase
         $source = '{% cache "k3" 300 %}{{ n }}{% endcache %}';
         $this->assertSame('first', $frond->renderString($source, ['n' => 'first']));
         $this->assertSame('first', $frond->renderString($source, ['n' => 'second']));
+    }
+
+    /** Read the TEMPLATE_CACHE_MAX cap straight off the class. */
+    private function templateCacheMax(): int
+    {
+        return (new ReflectionClass(Frond::class))->getConstant('TEMPLATE_CACHE_MAX');
+    }
+
+    /** @return array<string, array{content: string, time: int, ttl: int}> */
+    private function readFragmentCache(Frond $frond): array
+    {
+        // No setAccessible() call: private-property reads via Reflection need no
+        // unlocking since PHP 8.1, and the method is deprecated in 8.5.
+        return (new ReflectionClass(Frond::class))->getProperty('cache')->getValue($frond);
+    }
+
+    public function testFragmentCacheDoesNotGrowWithoutLimitForManyDistinctKeys(): void
+    {
+        $cap = $this->templateCacheMax();
+        $frond = new Frond(sys_get_temp_dir());
+        $distinct = $cap * 2 + 13;
+
+        for ($i = 0; $i < $distinct; $i++) {
+            $result = $frond->renderString('{% cache "frag' . $i . '" 300 %}{{ n }}{% endcache %}', ['n' => $i]);
+            $this->assertSame((string)$i, $result, "render #{$i}");
+        }
+
+        $size = count($this->readFragmentCache($frond));
+        $this->assertLessThanOrEqual(
+            $cap,
+            $size,
+            "fragment cache grew to {$size} entries for {$distinct} distinct keys; cap is {$cap}"
+        );
+    }
+
+    /** Negative control: the cap must not fire EARLY. */
+    public function testFragmentCacheEvictsNothingWhileUnderTheCap(): void
+    {
+        $cap = $this->templateCacheMax();
+        $frond = new Frond(sys_get_temp_dir());
+        $belowCap = $cap - 1;
+
+        for ($i = 0; $i < $belowCap; $i++) {
+            $frond->renderString('{% cache "under' . $i . '" 300 %}{{ n }}{% endcache %}', ['n' => $i]);
+        }
+
+        $this->assertCount($belowCap, $this->readFragmentCache($frond));
+    }
+
+    /**
+     * The bound must not cost correctness: a key evicted while still
+     * unexpired simply recomputes on next use instead of erroring or
+     * serving another key's content.
+     */
+    public function testFragmentCacheRecomputesAnEvictedFragmentAndStaysCorrect(): void
+    {
+        $cap = $this->templateCacheMax();
+        $frond = new Frond(sys_get_temp_dir());
+
+        $first = $frond->renderString('{% cache "first_evictable" 300 %}{{ n }}{% endcache %}', ['n' => 'one']);
+        $this->assertSame('one', $first);
+
+        for ($i = 0; $i < $cap * 2; $i++) {
+            $frond->renderString('{% cache "filler' . $i . '" 300 %}{{ n }}{% endcache %}', ['n' => $i]);
+        }
+
+        $keys = array_keys($this->readFragmentCache($frond));
+        $this->assertNotContains(
+            'first_evictable',
+            $keys,
+            'the first fragment should have been evicted by the size cap'
+        );
+
+        // Recomputes from cold with fresh data -- never reads stale content.
+        $recomputed = $frond->renderString('{% cache "first_evictable" 300 %}{{ n }}{% endcache %}', ['n' => 'two']);
+        $this->assertSame('two', $recomputed);
+    }
+
+    /**
+     * ADR-0004: a TTL-expired entry is SWEPT (removed from the array), not
+     * merely left stale for the next read of that same key to overwrite.
+     */
+    public function testFragmentCacheSweepsATtlExpiredEntryInsteadOfLeavingItStaleForever(): void
+    {
+        $frond = new Frond(sys_get_temp_dir());
+
+        $shortLived = $frond->renderString('{% cache "short_lived" 1 %}{{ n }}{% endcache %}', ['n' => 'first']);
+        $this->assertSame('first', $shortLived);
+        $frond->renderString('{% cache "control" 300 %}{{ n }}{% endcache %}', ['n' => 'control']);
+
+        sleep(2);
+
+        // Touch a DIFFERENT cache key -- proving the sweep runs as a side
+        // effect of any fragment-cache render, not only on a re-read of the
+        // SAME key (which the old code already handled by silent overwrite).
+        $frond->renderString('{% cache "trigger" 300 %}{{ n }}{% endcache %}', ['n' => 'trigger']);
+
+        $keys = array_keys($this->readFragmentCache($frond));
+        $this->assertNotContains(
+            'short_lived',
+            $keys,
+            'the expired entry should have been swept, not merely left stale'
+        );
+        $this->assertContains('control', $keys, 'a still-live entry must not be swept early');
+
+        // A fresh render recomputes rather than ever reading stale content.
+        $refreshed = $frond->renderString('{% cache "short_lived" 1 %}{{ n }}{% endcache %}', ['n' => 'second']);
+        $this->assertSame('second', $refreshed);
     }
 }

--- a/tests/FrondStaticFacadeTest.php
+++ b/tests/FrondStaticFacadeTest.php
@@ -31,6 +31,12 @@ class FrondStaticFacadeTest extends TestCase
 
     /* ───────── Static (class-level) registration ─────────── */
 
+    public function testClassRegistrationIsProcessGlobal(): void
+    {
+        Frond::addFilter('class_filter', fn($value) => 'class:' . $value);
+        $this->assertSame('class:value', (new Frond())->renderString('{{ "value" | class_filter }}'));
+    }
+
     public function testStaticAddFilterRegistersAtClassLevel(): void
     {
         Frond::addFilter('money', fn($v) => number_format((float)$v, 2));
@@ -86,37 +92,33 @@ class FrondStaticFacadeTest extends TestCase
         $this->assertSame('10', $out);
     }
 
-    public function testInstanceAddFilterAlsoPopulatesClassRegistry(): void
+    public function testInstanceFilterRegistrationIsInstanceLocal(): void
     {
-        // Instance registration should ALSO update the class registry so
-        // every subsequent ``new Frond()`` inherits the filter — this is
-        // the Python ``_ClassOrInstanceMethod`` semantics (instance call
-        // updates both the class state and the local instance state).
         $first = new Frond();
         $first->addFilter('shout', fn($v) => strtoupper((string)$v) . '!');
 
         $second = new Frond();
-        $this->assertArrayHasKey('shout', $second->getFilters());
-        $this->assertSame('HELLO!', $second->renderString('{{ "hello" | shout }}'));
+        $this->assertArrayNotHasKey('shout', $second->getFilters());
+        $this->assertSame('hello', $second->renderString('{{ "hello" | shout }}'));
     }
 
-    public function testInstanceAddGlobalAlsoPopulatesClassRegistry(): void
+    public function testInstanceGlobalRegistrationIsInstanceLocal(): void
     {
         $first = new Frond();
         $first->addGlobal('SITE', 'Tina4');
 
         $second = new Frond();
-        $this->assertSame('Tina4', $second->renderString('{{ SITE }}'));
+        $this->assertSame('', $second->renderString('{{ SITE }}'));
     }
 
-    public function testInstanceAddTestAlsoPopulatesClassRegistry(): void
+    public function testInstanceTestRegistrationIsInstanceLocal(): void
     {
         $first = new Frond();
-        $first->addTest('even', fn($v) => ((int)$v) % 2 === 0);
+        $first->addTest('is_four_only', fn($v) => ((int)$v) === 4);
 
         $second = new Frond();
-        $out = $second->renderString('{% if n is even %}yes{% else %}no{% endif %}', ['n' => 4]);
-        $this->assertSame('yes', $out);
+        $out = $second->renderString('{% if n is is_four_only %}yes{% else %}no{% endif %}', ['n' => 4]);
+        $this->assertSame('no', $out);
     }
 
     /* ───────── clearRegistry ─────────── */
@@ -178,19 +180,16 @@ class FrondStaticFacadeTest extends TestCase
         $this->assertSame('$99.50 - SALE!', $out);
     }
 
-    public function testInstanceRegisteredBeforeClassConstructionStillVisible(): void
+    public function testInstanceRegisteredBeforeClassConstructionStaysLocal(): void
     {
-        // Order matters: when an INSTANCE registers a filter, future
-        // instances must see it too — instance registration writes through
-        // to the class registry.
         $earlier = new Frond();
-        $earlier->addFilter('reverse', fn($v) => strrev((string)$v));
+        $earlier->addFilter('reverse_local_only', fn($v) => strrev((string)$v));
 
         // A later static registration adds a second filter
         Frond::addFilter('upper2', fn($v) => strtoupper((string)$v));
 
         $later = new Frond();
-        $this->assertSame('cba', $later->renderString('{{ "abc" | reverse }}'));
+        $this->assertSame('abc', $later->renderString('{{ "abc" | reverse_local_only }}'));
         $this->assertSame('HI', $later->renderString('{{ "hi" | upper2 }}'));
     }
 

--- a/tests/FrondTest.php
+++ b/tests/FrondTest.php
@@ -928,6 +928,44 @@ class FrondTest extends TestCase
         $this->assertSame('Title: Default Title', $result);
     }
 
+    public function testExtendsSingleStillWorks(): void
+    {
+        // Positive lock-in: one {% extends %} tag renders exactly as before.
+        $this->writeTemplate('base_solo.html', '<h1>{% block title %}Default{% endblock %}</h1>');
+        $this->writeTemplate('child_solo.html', '{% extends "base_solo.html" %}{% block title %}Solo{% endblock %}');
+        $result = $this->engine->render('child_solo.html', []);
+        $this->assertSame('<h1>Solo</h1>', $result);
+    }
+
+    public function testExtendsTwiceThrows(): void
+    {
+        // 3.13.100: a SECOND {% extends %} tag throws instead of being
+        // silently discarded. Before the fix, resolveInheritance() broke on
+        // the FIRST 'extends' AST node it found and never looked further, so
+        // the second extends target -- and the rest of the child's non-block
+        // content -- vanished with no signal. Mirrors the unknown-tag-throws
+        // policy (3.13.89): fail loud instead of guessing.
+        $this->writeTemplate('base_a.html', 'A {% block content %}{% endblock %}');
+        $this->writeTemplate('base_b.html', 'B {% block content %}{% endblock %}');
+        $this->writeTemplate(
+            'double.html',
+            "{% extends \"base_a.html\" %}\n{% extends \"base_b.html\" %}\n{% block content %}X{% endblock %}"
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/2 "\{% extends %\}" tags/');
+        $this->engine->render('double.html', []);
+    }
+
+    public function testExtendsTwiceThrowsViaRenderString(): void
+    {
+        // The same double-extends guard applies on the renderString() path.
+        $this->writeTemplate('base_a2.html', 'A');
+        $this->writeTemplate('base_b2.html', 'B');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/2 "\{% extends %\}" tags/');
+        $this->engine->renderString('{% extends "base_a2.html" %}{% extends "base_b2.html" %}', []);
+    }
+
     public function testExtendsWithLeadingWhitespace(): void
     {
         $this->writeTemplate('base3.html', '<html><body>{% block content %}default{% endblock %}</body></html>');

--- a/tests/FrondTest.php
+++ b/tests/FrondTest.php
@@ -2298,6 +2298,35 @@ TPL;
         $this->assertSame('MCHILDM', $this->engine->render('mln_child.html'));
     }
 
+    // Regression lock-in (3.13.100): PHP is the REFERENCE implementation for
+    // this case. Python/Node/Ruby's final block-substitution pass used a
+    // non-depth-aware regex, so a {% block %} the ROOT template nests INSIDE
+    // another {% block %} lost its wrapper AND its content -- pairing the
+    // outer block's open tag with the FIRST {% endblock %} found (the
+    // NESTED block's own close tag), which rendered "<section></section>"
+    // instead of "<section>LEAF</section>". PHP's AST-based
+    // resolveInheritance/replaceBlocks never had this bug: replaceBlocks
+    // walks the parsed tree (block nodes correctly nest their children at
+    // parse time, not via a flat regex re-scan), so an un-overridden outer
+    // block recurses into its OWN body to resolve a nested block placeholder
+    // regardless of which template in the chain declared the nesting. These
+    // two tests pin PHP's already-correct behaviour so it can never drift.
+    public function testRootNestedBlockSurvivesFinalSubstitution(): void
+    {
+        $this->writeTemplate('rnb_root.html', '{% block body %}<section>{% block inner %}{% endblock %}</section>{% endblock %}');
+        $this->writeTemplate('rnb_mid.html', '{% extends "rnb_root.html" %}{% block inner %}MID{% endblock %}');
+        $this->writeTemplate('rnb_leaf.html', '{% extends "rnb_mid.html" %}{% block inner %}LEAF{% endblock %}');
+        $this->assertSame('<section>LEAF</section>', $this->engine->render('rnb_leaf.html'));
+    }
+
+    public function testRootNestedBlockIntermediateOverrideSurvivesUntouchedLeaf(): void
+    {
+        $this->writeTemplate('rnbi_root.html', '{% block body %}<section>{% block inner %}{% endblock %}</section>{% endblock %}');
+        $this->writeTemplate('rnbi_mid.html', '{% extends "rnbi_root.html" %}{% block inner %}MID{% endblock %}');
+        $this->writeTemplate('rnbi_leaf.html', '{% extends "rnbi_mid.html" %}{% block unrelated %}unused{% endblock %}');
+        $this->assertSame('<section>MID</section>', $this->engine->render('rnbi_leaf.html'));
+    }
+
     public function testThreeLevelChildOnlyOverridesGrandparentBlock(): void
     {
         $this->writeTemplate('mlg_base.html', '{% block header %}H{% endblock %}|{% block body %}BODY{% endblock %}');

--- a/tests/fixtures/ai_fetch_retry_server.php
+++ b/tests/fixtures/ai_fetch_retry_server.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A REAL HTTP server whose responses follow a scripted sequence per path,
+ * used by AIFetchRetryTest to drive Tina4\AI::fetchBytes()'s retry loop over
+ * real sockets — no mocks, no monkeypatched curl/file_get_contents/sleep.
+ *
+ * Owns its own listener (`stream_socket_server`) rather than running under
+ * `php -S`, for the same reason as tests/fixtures/api_retry_server.php: it is
+ * one long-running process, so the hit counters below are exact and a test
+ * can assert "the client attempted N times" from the SERVER's point of view
+ * instead of counting inside the class under test.
+ *
+ * Usage:  php ai_fetch_retry_server.php <port>
+ *
+ * Routes:
+ *   GET /skill        -> hit 1 & 2: 503 "down"; hit 3+: 200 "skill body"
+ *   GET /missing      -> always 404 "not found"
+ *   GET /hits?path=P  -> {"hits": N} for path P (never counted itself)
+ */
+
+$port = (int)($argv[1] ?? 0);
+if ($port <= 0) {
+    fwrite(STDERR, "usage: ai_fetch_retry_server.php <port>\n");
+    exit(1);
+}
+
+$listener = @stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
+if ($listener === false) {
+    fwrite(STDERR, "could not bind 127.0.0.1:{$port}: {$errstr} ({$errno})\n");
+    exit(1);
+}
+
+/** @var array<string, int> hits seen per path (the /hits reporting route is excluded) */
+$hits = [];
+
+/** Reason phrases for the statuses this fixture emits. */
+$reason = [200 => 'OK', 404 => 'Not Found', 503 => 'Service Unavailable'];
+
+/**
+ * Write one complete HTTP/1.1 response and close the connection.
+ *
+ * @param resource $conn
+ */
+$respond = static function ($conn, int $status, string $body, string $contentType = 'application/octet-stream') use ($reason): void {
+    $head = "HTTP/1.1 {$status} " . ($reason[$status] ?? 'Status') . "\r\n"
+        . "Content-Type: {$contentType}\r\n"
+        . 'Content-Length: ' . strlen($body) . "\r\n"
+        . "Connection: close\r\n\r\n";
+    @fwrite($conn, $head . $body);
+    @fclose($conn);
+};
+
+while (true) {
+    $conn = @stream_socket_accept($listener, 60);
+    if ($conn === false) {
+        // Idle accept timeout — keep listening. The parent TestServer signals
+        // this process when the test class is done.
+        continue;
+    }
+
+    // Read the request line + headers. TestServer's readiness probe opens a
+    // connection and closes it without sending anything; that must NOT be
+    // counted as a hit, so a request with no request line is dropped.
+    stream_set_timeout($conn, 5);
+    $requestLine = fgets($conn);
+    if ($requestLine === false || trim($requestLine) === '') {
+        @fclose($conn);
+        continue;
+    }
+    while (($line = fgets($conn)) !== false) {
+        if ($line === "\r\n" || $line === "\n") {
+            break;
+        }
+    }
+
+    $target = explode(' ', trim($requestLine))[1] ?? '/';
+    $path = (string)parse_url($target, PHP_URL_PATH);
+    parse_str((string)parse_url($target, PHP_URL_QUERY), $query);
+
+    if ($path === '/hits') {
+        $key = (string)($query['path'] ?? '');
+        $respond($conn, 200, (string)json_encode(['hits' => $hits[$key] ?? 0]), 'application/json');
+        continue;
+    }
+
+    if ($path === '/skill') {
+        $hits[$path] = ($hits[$path] ?? 0) + 1;
+        $n = $hits[$path];
+        $n < 3
+            ? $respond($conn, 503, 'down')
+            : $respond($conn, 200, 'skill body');
+        continue;
+    }
+
+    if ($path === '/missing') {
+        $hits[$path] = ($hits[$path] ?? 0) + 1;
+        $respond($conn, 404, 'not found');
+        continue;
+    }
+
+    $respond($conn, 404, 'no such route: ' . $path);
+}


### PR DESCRIPTION
## Summary\n\n- complete the audited Tina4 3.13.100 parity work\n- make Frond class/global/test extensions process-global while keeping instance extensions local\n- include resilient skill installation and broaden the tina4-js trigger spellings\n- document tina4js 1.5.2 HTML-comment interpolation behavior\n\n## Verification\n\n- 5,495 tests and 19,274 assertions passed\n- feature audit plans closed\n- shared language-port fixtures validated\n\nThis release intentionally allows parity corrections before the 3.14.0 stability boundary.