### PR TITLE
Release 3.13.103

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           php-version: '8.2'
 
+      - name: Verify tag matches source version
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          SOURCE_VERSION="$(php -r "require 'Tina4/App.php'; echo \\Tina4\\App::\$VERSION;")"
+          test "$SOURCE_VERSION" = "$VERSION" || {
+            echo "::error::Tag $VERSION does not match Tina4/App.php $SOURCE_VERSION"
+            exit 1
+          }
+          echo "Publishing verified version $VERSION"
+
       - name: Extract release notes from commit body
         run: |
           # Pull the tagged commit body (sans Co-Authored-By trailers and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,40 @@ number means the same thing everywhere.
 **The authoritative release notes for every shipped version live in the documentation:**
 https://tina4.com/php/36-releases
 
-## 3.13.101
+## 3.13.103
+
+### Metrics reports what it can prove
+
+- Require signed Tina4 client 3.8.76 for the native metrics handoff.
+- Expose `has_referencing_test` as a source-reference signal. It does not claim
+  that a test ran or that coverage exists.
+- Fail when the native client is stale instead of falling back to a second
+  framework-owned analyser.
+
+### Frond stays stable and gets smaller
+
+- Split expression parsing and evaluation into focused internal steps.
+- Preserve public APIs and the shared 84-case expression corpus across all four
+  languages.
+
+### One client starts every project
+
+- Lead framework skills with `tina4 init` and `tina4 serve`.
+- Keep scaffolding guidance visible and separate runtime dependencies from
+  language extensions.
+
+### PHP connection timeout diagnosis
+
+- Treat libpq's explicit `timeout expired` result as the configured connection
+  timeout at the clock boundary, while preserving instant refusal errors.
+
+### Release integrity
+
+- Align source, runtime, package, lockfile, and AI-facing guide versions.
+- Reject a release tag that does not match the source package version before
+  any registry publish begins.
+
++## 3.13.101
 
 ### Breaking: metrics has one owner
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 PHP
 
-Version 3.13.101 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
+Version 3.13.103 - Full Tina4 PHP framework and application scaffold. See https://tina4.com for full documentation.
 
 ## Build & Test
 

--- a/Tina4/App.php
+++ b/Tina4/App.php
@@ -34,7 +34,7 @@ class App
      *
      * @var string
      */
-    public static string $VERSION = '3.13.101';
+    public static string $VERSION = '3.13.103';
 
     /**
      * The health path that is registered no matter what TINA4_HEALTH_PATH says.


### PR DESCRIPTION
## 3.13.103\n\nRestores one public version across Python, PHP, Ruby, and Node.js after the incomplete 3.13.102 registry publish.\n\n- requires signed Tina4 client 3.8.76 for native metrics handoff\n- preserves Frond APIs and the shared 84-case expression corpus\n- aligns source, runtime, package, lockfile, and AI guide versions\n- rejects tag/source version mismatches before publishing\n- adds no runtime package dependencies\n\n## Root lab gate\n\n- Python: 5,527 passed\n- PHP: 5,444 tests / 19,094 assertions\n- Ruby: 5,449 examples / 0 failures\n- Node.js: 8,436 passed / 0 skipped\n\nCo-Authored-By: Tina4 <82961293+tina4stack@users.noreply.github.com>