### PR TITLE
fix(migration): read the Firebird ledger generator under its folded key

### DIFF
--- a/Tina4/Migration.php
+++ b/Tina4/Migration.php
@@ -1084,10 +1084,10 @@ class Migration
         // for a v2-upgraded Firebird table (migration_id is its PK; it has no
         // `id` column nor the GEN_TINA4_MIGRATION_ID generator).
         if ($this->isFirebird() && !$this->hasLegacyMigrationIdColumn()) {
-            $rows = $this->db->query(
+            $rows = $this->queryLower(
                 "SELECT GEN_ID(GEN_TINA4_MIGRATION_ID, 1) AS NEXT_ID FROM RDB\$DATABASE"
             );
-            $columns['id'] = (int)($rows[0]['NEXT_ID'] ?? 1);
+            $columns['id'] = (int)($rows[0]['next_id'] ?? 1);
         }
 
         $names        = array_keys($columns);

--- a/tests/MigrationFirebirdLedgerIdTest.php
+++ b/tests/MigrationFirebirdLedgerIdTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * The migration ledger must give every row its own id on Firebird.
+ *
+ * Firebird has no AUTOINCREMENT, so recordMigration() supplies the tracking
+ * table's primary key itself: it reads GEN_TINA4_MIGRATION_ID and puts the
+ * value into the INSERT. That read asked for $rows[0]['NEXT_ID'], but since
+ * 3.13.99 FirebirdAdapter::columnName folds an unquoted upper-case alias to
+ * lower case — the behaviour FirebirdColumnCaseTest pins — so the key is
+ * 'next_id', the lookup missed, and the '?? 1' fallback handed EVERY row id 1.
+ * The first migration applied and the second died on the ledger's own primary
+ * key, so a Firebird database carrying the canonical v3 tracking table could
+ * not be migrated past its first file at all.
+ *
+ * THAT THE ADAPTER FOLDS IS ALREADY COVERED. What was not covered is whether
+ * the migration runner reads back what the adapter returns. A fold is only half
+ * a contract; the other half is each consumer of it, and this is the missing
+ * half for the ledger.
+ *
+ * WHY IT STAYED INVISIBLE. A tina4_migration upgraded from v2 keeps
+ * migration_id as its primary key and has neither an id column nor the
+ * generator, so hasLegacyMigrationIdColumn() short-circuits the branch and the
+ * bad read never executes. Every long-lived installation is that shape; only a
+ * freshly created database gets the canonical v3 table. The failure is total on
+ * new databases and absent on existing ones — the worst possible distribution
+ * for anyone noticing it.
+ *
+ * NO DOUBLES — this drives a real migration chain against a REAL Firebird
+ * server over TCP. A fake adapter would have to be told what the generator read
+ * returns, which is the exact thing in question.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Database\Database;
+use Tina4\Migration;
+
+class MigrationFirebirdLedgerIdTest extends TestCase
+{
+    /** Distinct names so a shared test server is never clobbered. */
+    private const T_ONE = 'nomock_ledger_one';
+    private const T_TWO = 'nomock_ledger_two';
+
+    private string $migrationsDir;
+
+    protected function setUp(): void
+    {
+        $this->migrationsDir = sys_get_temp_dir() . '/tina4_mig_ledger_' . uniqid();
+        mkdir($this->migrationsDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->migrationsDir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->migrationsDir);
+    }
+
+    private static function firebirdUrl(): string
+    {
+        $url = getenv('TINA4_TEST_FIREBIRD_URL');
+
+        return $url === false ? '' : $url;
+    }
+
+    private function firebirdOrSkip(): Database
+    {
+        if (!function_exists('ibase_connect') && !in_array('firebird', \PDO::getAvailableDrivers(), true)) {
+            $this->markTestSkipped('Firebird client not installed — neither ext-interbase nor pdo_firebird is available');
+        }
+
+        $url = self::firebirdUrl();
+        if ($url === '') {
+            $this->markTestSkipped(
+                'TINA4_TEST_FIREBIRD_URL is not set — no live Firebird was promised to this run, '
+                . 'so the ledger id case cannot run'
+            );
+        }
+
+        // THE CONNECTION IS THE PROBE, as in the other live Firebird tests: it
+        // is the only thing that establishes the database is really there and
+        // really usable, and its failure carries the server's own reason.
+        try {
+            $db = new Database($url);
+            $db->fetchOne('SELECT 1 AS N FROM RDB$DATABASE');
+        } catch (\Throwable $failure) {
+            $this->markTestSkipped(sprintf(
+                'Firebird cannot connect at %s — %s',
+                $url,
+                $failure->getMessage()
+            ));
+        }
+
+        return $db;
+    }
+
+    /**
+     * Drops the tracking table and its generator so the runner builds the
+     * CANONICAL v3 table, which is the only shape that reaches the branch under
+     * test. A v2-upgraded table would skip it and prove nothing.
+     */
+    private function resetLedger(Database $db): void
+    {
+        foreach (['DROP TABLE tina4_migration', 'DROP SEQUENCE GEN_TINA4_MIGRATION_ID'] as $ddl) {
+            try {
+                $db->execute($ddl);
+                $db->commit();
+            } catch (\Throwable) {
+                // Absent already — Firebird has no DROP ... IF EXISTS.
+            }
+        }
+    }
+
+    private function dropScratchTables(Database $db): void
+    {
+        foreach ([self::T_ONE, self::T_TWO] as $table) {
+            try {
+                $db->execute('DROP TABLE ' . $table);
+                $db->commit();
+            } catch (\Throwable) {
+                // Never created, or already gone.
+            }
+        }
+    }
+
+    /**
+     * Two migrations must BOTH apply, and their ledger rows must not collide.
+     *
+     * Two files is the smallest chain that can detect the defect: the first row
+     * is inserted whatever id it is given, so a chain of one passes even when
+     * every row is stamped with the same value. The collision only surfaces on
+     * the second.
+     */
+    public function testSecondMigrationDoesNotCollideOnTheLedgerPrimaryKey(): void
+    {
+        $db = $this->firebirdOrSkip();
+
+        try {
+            $this->dropScratchTables($db);
+            $this->resetLedger($db);
+
+            file_put_contents(
+                $this->migrationsDir . '/20260101000001_nomock_ledger_one.sql',
+                'CREATE TABLE ' . self::T_ONE . ' (id INTEGER)'
+            );
+            file_put_contents(
+                $this->migrationsDir . '/20260101000002_nomock_ledger_two.sql',
+                'CREATE TABLE ' . self::T_TWO . ' (id INTEGER)'
+            );
+
+            $result = (new Migration($db, $this->migrationsDir))->migrate();
+
+            $this->assertSame(
+                [],
+                $result['errors'],
+                'both migrations must apply; a violation of the tina4_migration '
+                . 'primary key here means every ledger row was stamped with the '
+                . 'same id'
+            );
+            $this->assertCount(2, $result['applied'], 'both migrations must be recorded');
+
+            // Read the ids back rather than trusting the return value: the
+            // defect is in what was WRITTEN to the ledger.
+            $rows = $db->fetchAll('SELECT id FROM tina4_migration');
+            $ids  = array_map(
+                static fn($row) => (int) (array_change_key_case((array) $row)['id'] ?? 0),
+                $rows
+            );
+
+            $this->assertCount(2, $ids, 'the ledger must hold one row per migration');
+            $this->assertSame(
+                $ids,
+                array_values(array_unique($ids)),
+                'each ledger row must carry its own id, not a repeated fallback'
+            );
+        } finally {
+            $this->dropScratchTables($db);
+            $this->resetLedger($db);
+            $db->close();
+        }
+    }
+}


### PR DESCRIPTION
## What's broken

On Firebird, `recordMigration()` supplies the tracking table's primary key itself, because the engine has no AUTOINCREMENT: it reads `GEN_TINA4_MIGRATION_ID` and puts the value into the INSERT.

That read asks for `$rows[0]['NEXT_ID']`. Since 3.13.99, `FirebirdAdapter::columnName` folds an unquoted upper-case alias to lower case — the behaviour `FirebirdColumnCaseTest` pins — so the key is `next_id`. The lookup misses, the `?? 1` fallback fires, and **every ledger row is stamped with `id = 1`**. The first migration applies; the second dies on the ledger's own primary key.

The effect is total: a Firebird database whose `tina4_migration` carries the canonical v3 shape cannot be migrated past its first file.

```
Migration applied: 20221231000001_Initial_migrations_for_the_system.sql
Migration failed:  20221231000002_Add_Tables.sql — violation of PRIMARY or
UNIQUE KEY constraint "INTEG_2" on table "TINA4_MIGRATION"
Problematic key value is ("ID" = 1)
```

## Why it hasn't been reported

A `tina4_migration` upgraded from v2 keeps `migration_id` as its primary key and has neither an `id` column nor the generator, so `hasLegacyMigrationIdColumn()` short-circuits the branch and the bad read never executes. Every long-lived installation is that shape.

Only a **freshly created** database gets the canonical v3 table. So the failure is total on new databases and absent on existing ones — the worst possible distribution for anyone noticing it. It surfaced here only because we stood up a brand-new Firebird to run a test harness against.

## The fix

Use the class's own `queryLower()` helper, which exists for exactly this and already backs the other tracking-table reads:

> Column names are referenced in lower case throughout this class, so keys are normalised here to read the same across adapters that report them in different cases (Firebird, for example, returns upper-case keys).

This call site was simply missed when the fold landed — it's the only upper-case key read left in the file.

## Verification

Against a real Firebird 3.0.9 with a 145-file migration chain:

- **before** — 1 migration applied, run died on the second with the PK violation above
- **after** — the full chain applies

`tests/MigrationFirebirdLedgerIdTest.php` pins it, and was checked both ways: red before the fix, green after. Two files is the smallest chain that can detect it — a one-file chain stays green even when every row is stamped with the same id, which is why the failure appears on migration 2.

The test resets `tina4_migration` and its generator so the runner builds the canonical v3 table, since a v2-upgraded table skips the branch and would prove nothing. Real Firebird over TCP, gated on `TINA4_TEST_FIREBIRD_URL`, skipping in the wording `RequireServicesGate` recognises. No doubles — a fake adapter would have to be told what the generator read returns, which is the thing in question.

## Notes for reviewers

- `fix/firebird-column-case` and `feature/release3.13.104` both still carry this read, so 3.13.104 ships with it.
- **The Python master gets this right** — `tina4_python` reads `row["next_id"]` against the same fold. Ruby is defensive: `row[:NEXT_ID] || row[:next_id] || 1`. The PHP port transcribed the SQL alias's written case into the key lookup rather than the case the adapter returns.
- The `?? 1` fallback silently produces a duplicate key whenever the read fails. Out of scope here, but throwing would turn a corrupt ledger into a loud error.
