### PR TITLE
fix(cache): stop ResponseCache replaying one session's response to another

### DIFF
--- a/Tina4/Middleware/ResponseCache.php
+++ b/Tina4/Middleware/ResponseCache.php
@@ -688,6 +688,50 @@ class ResponseCache
     }
 
     /**
+     * The Cache-Control directive NAMES on a request or response, lowercased.
+     *
+     * Parsed as comma-separated tokens with any ="value" stripped, rather than
+     * by substring search, so no-cache="Set-Cookie" is recognised as no-cache
+     * and a directive name never matches as a fragment of a longer one.
+     *
+     * @param object $carrier Request or Response carrying a Cache-Control header
+     * @return string[] Lowercased directive names, empty when there is none
+     */
+    private function cacheControlTokens(object $carrier): array
+    {
+        $raw = (string)$this->headerValue($carrier, 'Cache-Control');
+        if (trim($raw) === '') {
+            return [];
+        }
+        $tokens = [];
+        foreach (explode(',', $raw) as $token) {
+            $name = strtolower(trim(explode('=', $token, 2)[0]));
+            if ($name !== '') {
+                $tokens[] = $name;
+            }
+        }
+        return $tokens;
+    }
+
+    /**
+     * Does the response carry a directive that lets a SHARED cache store it?
+     *
+     * RFC 9111 s3.5 — a response to an Authorization/Cookie-bearing request (or
+     * one installing a Set-Cookie) is storable by a shared cache only when it
+     * opts in with an explicit shared-cache directive (public / s-maxage / …).
+     *
+     * @param object $response The response being considered for storage
+     * @return bool True when a shared-cache directive is present
+     */
+    private function sharedCacheAllowed(object $response): bool
+    {
+        return array_intersect(
+            $this->cacheControlTokens($response),
+            self::SHARED_CACHE_DIRECTIVES
+        ) !== [];
+    }
+
+    /**
      * May a SHARED cache store this response? (RFC 9111 s3, s4.1)
      *
      * s3 — "if the cache is shared: the Authorization header field is not
@@ -695,6 +739,23 @@ class ResponseCache
      * explicitly allows shared caching". The key is method + URL only, so
      * without this one authenticated caller's body is replayed to every later
      * caller of the same URL.
+     *
+     * The same s3 reasoning covers two cases the Authorization check alone does
+     * not:
+     *
+     *   - no-store forbids storage in any cache and private forbids it in a
+     *     shared one; no-cache forbids reuse without revalidation. Honouring
+     *     them gives a handler a standard way to keep a response out of this
+     *     cache — setting the correct header used to do nothing.
+     *   - A caller identified by a session Cookie is as specific as one carrying
+     *     Authorization, and Tina4's own session mechanism IS a cookie. Because
+     *     the key is method + URL, storing such a response replays one signed-in
+     *     user's page to whoever asks for that URL next. A response installing a
+     *     session (Set-Cookie) is per-user by construction for the same reason.
+     *
+     * Both cookie cases stay cacheable when the response opts in explicitly with
+     * a shared-cache directive, so a genuinely public page served to
+     * cookie-bearing browsers keeps its hit rate.
      *
      * s4.1 — a stored response whose Vary contains "*" "always fails to
      * match", so storing one is pointless.
@@ -708,16 +769,19 @@ class ResponseCache
         if (in_array('*', $this->varyFields($response), true)) {
             return false;
         }
-        if ($this->headerValue($request, 'Authorization') === null) {
-            return true;
+        if (array_intersect($this->cacheControlTokens($response), ['no-store', 'private', 'no-cache']) !== []) {
+            return false;
         }
-        $cacheControl = strtolower((string)$this->headerValue($response, 'Cache-Control'));
-        foreach (self::SHARED_CACHE_DIRECTIVES as $directive) {
-            if (str_contains($cacheControl, $directive)) {
-                return true;
-            }
+        if ($this->headerValue($request, 'Authorization') !== null) {
+            return $this->sharedCacheAllowed($response);
         }
-        return false;
+        if ($this->headerValue($request, 'Cookie') !== null) {
+            return $this->sharedCacheAllowed($response);
+        }
+        if ($this->headerValue($response, 'Set-Cookie') !== null) {
+            return $this->sharedCacheAllowed($response);
+        }
+        return true;
     }
 
     /**

--- a/tests/ResponseCacheRfc9111Test.php
+++ b/tests/ResponseCacheRfc9111Test.php
@@ -146,4 +146,118 @@ class ResponseCacheRfc9111Test extends TestCase
         $this->assertTrue($ran, 'Vary:* always fails to match, so it must never be stored');
         $this->assertStringContainsString('recomputed', $res->getBody());
     }
+
+    // -- Session-cookie isolation (#117, port of Python) ---------------------
+
+    public function testResponseSettingSetCookieIsNotReplayedToAnotherSession(): void
+    {
+        // Core security regression: a GET whose response installs a Set-Cookie
+        // is built for one caller, so it must NOT be replayed from cache.
+        $cache = new ResponseCache(['ttl' => 60]);
+        $installsSession = static function (Request $req, Response $res): Response {
+            $res->header('Set-Cookie', 'session=ALICE; Path=/; HttpOnly');
+            return $res->json(['v' => 'alice-secret']);
+        };
+
+        $alice = Request::create(method: 'GET', path: '/api/me');
+        $cache->handle($alice, new Response(testing: true), $installsSession);
+
+        // A second request must MISS — the handler runs, alice's body is not served.
+        $ran = false;
+        $bob = Request::create(method: 'GET', path: '/api/me');
+        $bobRes = $cache->handle($bob, new Response(testing: true), function (Request $q, Response $r) use (&$ran): Response {
+            $ran = true;
+            return $r->json(['v' => 'bob']);
+        });
+        $this->assertTrue($ran, 'a Set-Cookie response must not be served from the shared cache');
+        $this->assertStringNotContainsString('alice-secret', $bobRes->getBody());
+        $this->assertSame('MISS', $bobRes->getHeader('X-Cache'));
+    }
+
+    public function testCookieRequestWithoutSharedDirectiveIsNotCached(): void
+    {
+        // A request carrying a Cookie is as specific as an authenticated one.
+        // With no shared-cache directive on the response it must not be stored.
+        $cache = new ResponseCache(['ttl' => 60]);
+
+        $alice = Request::create(method: 'GET', path: '/api/dashboard', headers: ['cookie' => 'session=ALICE']);
+        $cache->handle($alice, new Response(testing: true), $this->handlerReturning('alice-dashboard'));
+
+        $ran = false;
+        $bob = Request::create(method: 'GET', path: '/api/dashboard', headers: ['cookie' => 'session=BOB']);
+        $bobRes = $cache->handle($bob, new Response(testing: true), function (Request $q, Response $r) use (&$ran): Response {
+            $ran = true;
+            return $r->json(['v' => 'bob-dashboard']);
+        });
+        $this->assertTrue($ran, 'a cookie-bearing request without a shared directive must miss');
+        $this->assertStringNotContainsString('alice-dashboard', $bobRes->getBody());
+        $this->assertSame('MISS', $bobRes->getHeader('X-Cache'));
+    }
+
+    public function testPrivateNoStoreNoCacheResponsesAreNotCached(): void
+    {
+        // Cache-Control: private / no-store / no-cache must all keep a response
+        // out of the shared cache, even for cookieless traffic.
+        foreach (['private', 'no-store', 'no-cache', 'no-cache="Set-Cookie"'] as $directive) {
+            $cache = new ResponseCache(['ttl' => 60]);
+            $refusing = static function (Request $req, Response $res) use ($directive): Response {
+                $res->header('Cache-Control', $directive);
+                return $res->json(['v' => 'do-not-store']);
+            };
+
+            $first = Request::create(method: 'GET', path: '/api/secret');
+            $cache->handle($first, new Response(testing: true), $refusing);
+
+            $ran = false;
+            $second = Request::create(method: 'GET', path: '/api/secret');
+            $res = $cache->handle($second, new Response(testing: true), function (Request $q, Response $r) use (&$ran): Response {
+                $ran = true;
+                return $r->json(['v' => 'recomputed']);
+            });
+            $this->assertTrue($ran, "Cache-Control: {$directive} must keep the response out of the cache");
+            $this->assertStringContainsString('recomputed', $res->getBody());
+        }
+    }
+
+    public function testCookieRequestMarkedPublicStillHits(): void
+    {
+        // Control: a cookie-bearing request whose response is explicitly public
+        // must still be served from cache (the fix is not "disable caching").
+        $cache = new ResponseCache(['ttl' => 60]);
+        $publicHandler = static function (Request $req, Response $res): Response {
+            $res->header('Cache-Control', 'public, max-age=60');
+            return $res->json(['v' => 'shared-products']);
+        };
+
+        $first = Request::create(method: 'GET', path: '/api/products', headers: ['cookie' => 'session=ALICE']);
+        $cache->handle($first, new Response(testing: true), $publicHandler);
+
+        $ran = false;
+        $second = Request::create(method: 'GET', path: '/api/products', headers: ['cookie' => 'session=BOB']);
+        $res = $cache->handle($second, new Response(testing: true), function (Request $q, Response $r) use (&$ran): Response {
+            $ran = true;
+            return $r->json(['v' => 'recomputed']);
+        });
+        $this->assertFalse($ran, 'a public response stays cacheable for cookie-bearing browsers');
+        $this->assertSame('HIT', $res->getHeader('X-Cache'));
+        $this->assertStringContainsString('shared-products', $res->getBody());
+    }
+
+    public function testCookielessPublicTrafficStillHits(): void
+    {
+        // Control: ordinary cookieless traffic must still HIT.
+        $cache = new ResponseCache(['ttl' => 60]);
+        $first = Request::create(method: 'GET', path: '/api/anon');
+        $cache->handle($first, new Response(testing: true), $this->handlerReturning('anon-body'));
+
+        $ran = false;
+        $second = Request::create(method: 'GET', path: '/api/anon');
+        $res = $cache->handle($second, new Response(testing: true), function (Request $q, Response $r) use (&$ran): Response {
+            $ran = true;
+            return $r->json(['v' => 'recomputed']);
+        });
+        $this->assertFalse($ran, 'cookieless public traffic must still be served from cache');
+        $this->assertSame('HIT', $res->getHeader('X-Cache'));
+        $this->assertStringContainsString('anon-body', $res->getBody());
+    }
 }


### PR DESCRIPTION
## The leak (real, measured in Python #117)

`ResponseCache` keys entries on **method + URL only**, and `mayStore()` guarded exactly two things: a `Vary: *` value and the `Authorization` request header. A request carrying a **Cookie** and no Authorization fell through to a bare `return true`, so its response was stored and served to whoever requested that URL next.

Tina4's own session mechanism **is a cookie**, so every session-authenticated page was replayable: a second request sending a different session cookie received the first user's response with `X-Cache: HIT`, and the handler never ran. There was also no way for a handler to opt out — `no-store` / `private` / `no-cache` were honoured nowhere.

## The fix (`Tina4/Middleware/ResponseCache.php`)

`mayStore()` becomes, in order:
1. `Vary: *` → not stored (unchanged).
2. **NEW** response `Cache-Control` contains `no-store` / `private` / `no-cache` → not stored.
3. request has `Authorization` → `sharedCacheAllowed(response)` (unchanged behaviour).
4. **NEW** request has `Cookie` → `sharedCacheAllowed(response)`.
5. **NEW** response has `Set-Cookie` → `sharedCacheAllowed(response)`.
6. else → stored.

Two new private helpers:
- `cacheControlTokens()` — parses `Cache-Control` into a set of directive **names** (comma-split, `=value` stripped), so `no-cache="Set-Cookie"` counts as `no-cache` and a name never matches as a fragment of a longer one.
- `sharedCacheAllowed()` — the old inline substring check refactored to a token-based intersection with `SHARED_CACHE_DIRECTIVES` (`public` / `s-maxage` / `must-revalidate`).

A cookie-bearing request whose response is explicitly `public` stays cacheable, so public-traffic hit rate is unchanged.

## Tests (`tests/ResponseCacheRfc9111Test.php`, real Request/Response + real ResponseCache — no mocks)

- `testResponseSettingSetCookieIsNotReplayedToAnotherSession` — core security regression
- `testCookieRequestWithoutSharedDirectiveIsNotCached`
- `testPrivateNoStoreNoCacheResponsesAreNotCached` (covers `no-cache="Set-Cookie"` token parsing)
- `testCookieRequestMarkedPublicStillHits` (control)
- `testCookielessPublicTrafficStillHits` (control)

The three security tests **fail against the unfixed `mayStore`** (mutation-proven by running them against HEAD) and pass with the fix; the two controls pass in both. Full file: `OK (10 tests, 32 assertions)`; both ResponseCache files together `OK (38 tests, 92 assertions)` on PHP 8.4.8 (Windows).

Port of Python #117 for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)