### PR TITLE
feat(graph): graph database layer — Ultipa, Neo4j, Memgraph, ArangoDB (Feature 139)

### DIFF
--- a/Tina4/Graph/ArangoGraphAdapter.php
+++ b/Tina4/Graph/ArangoGraphAdapter.php
@@ -1,0 +1,317 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+use ArangoDBClient\Collection;
+use ArangoDBClient\CollectionHandler;
+use ArangoDBClient\Connection;
+use ArangoDBClient\ConnectionOptions;
+use ArangoDBClient\Exception as ArangoException;
+use ArangoDBClient\Statement;
+
+/**
+ * ArangoDB graph adapter — the document/AQL engine behind the same surface.
+ *
+ * Wraps the community `triagens/arangodb` driver (an OPTIONAL dependency,
+ * referenced only inside this class so referencing Tina4\Graph stays driver-free).
+ * The driver is pure PHP over HTTP, so it needs no C extension. Arango is a
+ * document store, not a labelled-property graph, so the portable core maps onto
+ * ONE vertex collection + ONE edge collection: a node's `labels` and an edge's
+ * `type` are stored as document fields, ids are Arango `_id` handles (e.g.
+ * `tina4_nodes/123`), and traversal uses AQL `FOR v IN 1..N OUTBOUND ...`. Raw
+ * query()/execute() take AQL directly.
+ *
+ * The exact statements mirror the Python master
+ * (tina4_python/graph/adapters/arango.py) and are verified live on the lab.
+ */
+class ArangoGraphAdapter extends GraphAdapter
+{
+    public const VERTEX_COLLECTION = 'tina4_nodes';
+    public const EDGE_COLLECTION = 'tina4_edges';
+
+    /** @var array<int, string> Internal keys dropped when returning node/edge props. */
+    private const RESERVED = ['_id', '_key', '_rev', '_from', '_to', '_labels', '_type'];
+
+    private GraphUrl $url;
+
+    private Connection $connection;
+
+    /**
+     * @param GraphUrl $graphUrl The parsed graph URL
+     * @param string $username Fallback username when the URL omits one
+     * @param string $password Fallback password when the URL omits one
+     */
+    public function __construct(GraphUrl $graphUrl, string $username = '', string $password = '')
+    {
+        $this->url = $graphUrl;
+
+        $user = $graphUrl->username ?? ($username !== '' ? $username : 'root');
+        $pass = $graphUrl->password ?? ($password !== '' ? $password : '');
+        $database = $graphUrl->graph ?? '_system';
+
+        $scheme = $graphUrl->useTls ? 'ssl' : 'tcp';
+        $endpoint = $scheme . '://' . $graphUrl->host . ':' . ($graphUrl->port ?? 8529);
+
+        $options = [
+            ConnectionOptions::OPTION_ENDPOINT => $endpoint,
+            ConnectionOptions::OPTION_AUTH_TYPE => 'Basic',
+            ConnectionOptions::OPTION_AUTH_USER => $user,
+            ConnectionOptions::OPTION_AUTH_PASSWD => $pass,
+            ConnectionOptions::OPTION_DATABASE => $database,
+        ];
+
+        // null (unbounded, <= 0) leaves the driver's own default timeout.
+        $timeout = GraphConnectTimeout::resolveSeconds();
+        if ($timeout !== null) {
+            $options[ConnectionOptions::OPTION_CONNECT_TIMEOUT] = (int) ceil($timeout);
+            $options[ConnectionOptions::OPTION_TIMEOUT] = $timeout;
+        }
+
+        try {
+            $this->connection = new Connection($options);
+            // Force the (lazy) connection and ensure the two collections exist.
+            $handler = new CollectionHandler($this->connection);
+            if (!$handler->has(self::VERTEX_COLLECTION)) {
+                $handler->create(self::VERTEX_COLLECTION);
+            }
+            if (!$handler->has(self::EDGE_COLLECTION)) {
+                $edge = new Collection(self::EDGE_COLLECTION);
+                $edge->setType(Collection::TYPE_EDGE);
+                $handler->create($edge);
+            }
+        } catch (ArangoException $exception) {
+            $this->lastError = $exception->getMessage();
+            throw $this->connectOrError($exception);
+        }
+    }
+
+    // -- connection + raw pass-through -------------------------------------
+
+    /**
+     * Run one AQL statement with bind vars, translating driver errors.
+     *
+     * @param string $query The AQL statement
+     * @param array<string, mixed>|null $bind Bind variables
+     * @return array<int, mixed> The flat result rows
+     * @throws GraphConnectTimeout When the host is unreachable within the bound
+     * @throws GraphError When the statement fails
+     */
+    private function aql(string $query, ?array $bind = null): array
+    {
+        try {
+            $statement = new Statement($this->connection, [
+                'query' => $query,
+                'bindVars' => $bind ?? [],
+                '_flat' => true,
+            ]);
+
+            return $statement->execute()->getAll();
+        } catch (ArangoException $exception) {
+            $this->lastError = $exception->getMessage();
+            throw $this->connectOrError($exception);
+        }
+    }
+
+    /**
+     * Run a raw AQL read with bind vars and return a GraphResult.
+     *
+     * @param string $text The AQL read statement
+     * @param array<string, mixed>|null $params Bind variables
+     */
+    public function query(string $text, ?array $params = null): GraphResult
+    {
+        $rows = $this->aql($text, $params);
+        $columns = ($rows !== [] && is_array($rows[0])) ? array_keys($rows[0]) : [];
+
+        /** @var array<int, array<string, mixed>> $records */
+        $records = array_map(static fn (mixed $row): array => is_array($row) ? $row : ['value' => $row], $rows);
+
+        return new GraphResult($records, $columns);
+    }
+
+    /**
+     * Run a raw AQL write with bind vars and return a GraphResult.
+     *
+     * @param string $text The AQL write statement
+     * @param array<string, mixed>|null $params Bind variables
+     */
+    public function execute(string $text, ?array $params = null): GraphResult
+    {
+        return $this->query($text, $params);
+    }
+
+    // -- portable node/edge/traverse core (AQL) ----------------------------
+
+    public function addNode(string $label, ?array $properties = null): ?GraphNode
+    {
+        $doc = $properties ?? [];
+        $doc['_labels'] = [$label];
+        $rows = $this->aql('INSERT @doc INTO ' . self::VERTEX_COLLECTION . ' RETURN NEW', ['doc' => $doc]);
+
+        return isset($rows[0]) ? $this->nodeFromDoc($rows[0]) : null;
+    }
+
+    public function addEdge(mixed $fromId, mixed $toId, string $type, ?array $properties = null): ?GraphEdge
+    {
+        $doc = $properties ?? [];
+        $doc['_from'] = $fromId;
+        $doc['_to'] = $toId;
+        $doc['_type'] = $type;
+        $rows = $this->aql('INSERT @doc INTO ' . self::EDGE_COLLECTION . ' RETURN NEW', ['doc' => $doc]);
+
+        if (!isset($rows[0]) || !is_array($rows[0])) {
+            return null;
+        }
+        $row = $rows[0];
+
+        return new GraphEdge(
+            $row['_id'] ?? null,
+            (string) ($row['_type'] ?? $type),
+            $row['_from'] ?? null,
+            $row['_to'] ?? null,
+            $this->cleanProps($row)
+        );
+    }
+
+    public function getNode(mixed $nodeId): ?GraphNode
+    {
+        $rows = $this->aql('RETURN DOCUMENT(@id)', ['id' => $nodeId]);
+
+        return (isset($rows[0]) && is_array($rows[0])) ? $this->nodeFromDoc($rows[0]) : null;
+    }
+
+    public function updateNode(mixed $nodeId, array $properties): ?GraphNode
+    {
+        $rows = $this->aql(
+            'UPDATE PARSE_IDENTIFIER(@id).key WITH @props IN ' . self::VERTEX_COLLECTION . ' RETURN NEW',
+            ['id' => $nodeId, 'props' => $properties]
+        );
+
+        return (isset($rows[0]) && is_array($rows[0])) ? $this->nodeFromDoc($rows[0]) : null;
+    }
+
+    public function deleteNode(mixed $nodeId): bool
+    {
+        // Remove any edges touching the node first, so a re-read is a clean miss.
+        $this->aql(
+            'FOR e IN ' . self::EDGE_COLLECTION . ' FILTER e._from == @id OR e._to == @id '
+            . 'REMOVE e IN ' . self::EDGE_COLLECTION,
+            ['id' => $nodeId]
+        );
+        $this->aql(
+            'REMOVE PARSE_IDENTIFIER(@id).key IN ' . self::VERTEX_COLLECTION,
+            ['id' => $nodeId]
+        );
+
+        return true;
+    }
+
+    public function neighbors(mixed $nodeId, string $direction = 'both', ?string $edgeType = null, int $limit = 100): array
+    {
+        $dir = $this->arangoDirection($direction);
+        $typeFilter = $edgeType !== null ? 'FILTER e._type == @etype ' : '';
+        $bind = ['start' => $nodeId, 'limit' => $limit];
+        if ($edgeType !== null) {
+            $bind['etype'] = $edgeType;
+        }
+        $rows = $this->aql(
+            'FOR v, e IN 1..1 ' . $dir . ' @start ' . self::EDGE_COLLECTION . ' '
+            . $typeFilter . 'LIMIT @limit RETURN DISTINCT v',
+            $bind
+        );
+
+        return array_map(fn (mixed $doc): ?GraphNode => is_array($doc) ? $this->nodeFromDoc($doc) : null, $rows);
+    }
+
+    public function traverse(mixed $startId, int $depth = 1, string $direction = 'both', ?string $edgeType = null, int $limit = 1000): array
+    {
+        $dir = $this->arangoDirection($direction);
+        $typeFilter = $edgeType !== null ? 'FILTER e._type == @etype ' : '';
+        $bind = ['start' => $startId, 'limit' => $limit];
+        if ($edgeType !== null) {
+            $bind['etype'] = $edgeType;
+        }
+        $rows = $this->aql(
+            'FOR v, e IN 1..' . (int) $depth . ' ' . $dir . ' @start ' . self::EDGE_COLLECTION . ' '
+            . $typeFilter . 'LIMIT @limit RETURN DISTINCT v',
+            $bind
+        );
+
+        return array_map(fn (mixed $doc): ?GraphNode => is_array($doc) ? $this->nodeFromDoc($doc) : null, $rows);
+    }
+
+    public function close(): void
+    {
+        // The driver's HTTP connection is closed on destruction; dropping the
+        // reference releases it. Nothing explicit to do.
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    /**
+     * Map a portable direction to Arango's AQL keyword.
+     *
+     * @param string $direction One of "out", "in", "both"
+     */
+    private function arangoDirection(string $direction): string
+    {
+        return match ($direction) {
+            'out' => 'OUTBOUND',
+            'in' => 'INBOUND',
+            default => 'ANY',
+        };
+    }
+
+    /**
+     * Build a GraphNode from an Arango vertex document array.
+     *
+     * @param array<string, mixed> $doc
+     */
+    private function nodeFromDoc(array $doc): GraphNode
+    {
+        /** @var array<int, string> $labels */
+        $labels = $doc['_labels'] ?? [];
+
+        return new GraphNode($doc['_id'] ?? null, $labels, $this->cleanProps($doc));
+    }
+
+    /**
+     * Drop Arango's internal keys, leaving only user properties.
+     *
+     * @param array<string, mixed> $doc
+     * @return array<string, mixed>
+     */
+    private function cleanProps(array $doc): array
+    {
+        return array_diff_key($doc, array_flip(self::RESERVED));
+    }
+
+    /**
+     * Map a driver connect/timeout error to GraphConnectTimeout, others to GraphError.
+     *
+     * @param ArangoException $exception The driver exception
+     */
+    private function connectOrError(ArangoException $exception): GraphError|GraphConnectTimeout
+    {
+        $text = strtolower($exception->getMessage());
+        foreach (['timed out', 'timeout', 'connection', 'could not connect', 'max retries', 'refused', 'unreachable'] as $needle) {
+            if (str_contains($text, $needle)) {
+                return new GraphConnectTimeout(
+                    'Graph connect to ' . $this->url->host . ':' . $this->url->port . ' timed out '
+                    . '(TINA4_GRAPH_CONNECT_TIMEOUT). Raise it if the server is simply slow, or set '
+                    . 'it to 0 to wait indefinitely.',
+                    0,
+                    $exception
+                );
+            }
+        }
+
+        return new GraphError($exception->getMessage(), 0, $exception);
+    }
+}

--- a/Tina4/Graph/BoltGraphAdapter.php
+++ b/Tina4/Graph/BoltGraphAdapter.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+use Laudis\Neo4j\Authentication\Authenticate;
+use Laudis\Neo4j\ClientBuilder;
+use Laudis\Neo4j\Contracts\ClientInterface;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Exception\Neo4jException;
+use Laudis\Neo4j\Types\CypherMap;
+
+/**
+ * Bolt graph adapter — Neo4j AND Memgraph (both speak Bolt + Cypher).
+ *
+ * Wraps the community `laudis/neo4j-php-client` driver (an OPTIONAL dependency,
+ * referenced only inside this class so referencing Tina4\Graph stays driver-free).
+ * Neo4j and Memgraph share this ONE adapter; the URL scheme only picks the engine
+ * label and the default port. The driver is pure PHP over sockets (needs no C
+ * extension), so it serves both engines from the same wire protocol.
+ *
+ * Cypher note (verified live against Neo4j + Memgraph on the lab): `id(n)` is the
+ * portable node/edge id (an integer on both — Neo4j's `elementId` is Neo4j-only,
+ * Memgraph has no `elementId`); variable-length traversal is Cypher's `[*1..N]`
+ * (the OPPOSITE of Ultipa's GQL `{1,N}`); `SET n += $props` merges. The exact
+ * statements mirror the Python master (tina4_python/graph/adapters/bolt.py).
+ */
+class BoltGraphAdapter extends GraphAdapter
+{
+    private GraphUrl $url;
+
+    private ClientInterface $client;
+
+    private ?string $database;
+
+    /**
+     * @param GraphUrl $graphUrl The parsed graph URL
+     * @param string $username Fallback username when the URL omits one
+     * @param string $password Fallback password when the URL omits one
+     */
+    public function __construct(GraphUrl $graphUrl, string $username = '', string $password = '')
+    {
+        $this->url = $graphUrl;
+        $this->database = $graphUrl->graph;
+
+        $user = $graphUrl->username ?? ($username !== '' ? $username : 'neo4j');
+        $pass = $graphUrl->password ?? ($password !== '' ? $password : '');
+
+        $scheme = $graphUrl->useTls ? 'bolt+s' : 'bolt';
+        $uri = $scheme . '://' . $graphUrl->host . ':' . ($graphUrl->port ?? 7687);
+
+        // null (unbounded, <= 0) leaves the driver's own default socket timeout.
+        $timeout = GraphConnectTimeout::resolveSeconds();
+
+        $this->client = ClientBuilder::create()
+            ->withDriver('bolt', $uri, Authenticate::basic($user, $pass), $timeout)
+            ->withDefaultDriver('bolt')
+            ->build();
+    }
+
+    // -- connection + raw pass-through -------------------------------------
+
+    /**
+     * Run one Cypher statement with bound params, translating driver errors.
+     *
+     * @param string $cypher The Cypher statement
+     * @param array<string, mixed>|null $params Bound parameters
+     * @return array<int, array<string, mixed>> The plain associative result rows
+     * @throws GraphConnectTimeout When the host is unreachable within the bound
+     * @throws GraphError When the statement fails
+     */
+    private function run(string $cypher, ?array $params = null): array
+    {
+        try {
+            $result = $this->session()->run($cypher, $params ?? []);
+        } catch (Neo4jException $exception) {
+            $this->lastError = $exception->getMessage();
+            throw new GraphError($exception->getMessage(), 0, $exception);
+        } catch (\Throwable $exception) {
+            // An unreachable host surfaces here as a socket/connection failure.
+            $this->lastError = $exception->getMessage();
+            if ($this->looksLikeConnectFailure($exception)) {
+                throw new GraphConnectTimeout(
+                    'Graph connect to ' . $this->url->host . ':' . $this->url->port . ' timed out '
+                    . '(TINA4_GRAPH_CONNECT_TIMEOUT). Raise it if the server is simply slow, or set '
+                    . 'it to 0 to wait indefinitely.',
+                    0,
+                    $exception
+                );
+            }
+            throw new GraphError($exception->getMessage(), 0, $exception);
+        }
+
+        $rows = [];
+        foreach ($result as $record) {
+            $rows[] = $this->toPlain($record);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Run a raw Cypher read with bound params and return a GraphResult.
+     *
+     * @param string $text The Cypher read statement
+     * @param array<string, mixed>|null $params Bound parameters
+     */
+    public function query(string $text, ?array $params = null): GraphResult
+    {
+        $rows = $this->run($text, $params);
+        $columns = $rows !== [] ? array_keys($rows[0]) : [];
+
+        return new GraphResult($rows, $columns);
+    }
+
+    /**
+     * Run a raw Cypher write with bound params and return a GraphResult.
+     *
+     * @param string $text The Cypher write statement
+     * @param array<string, mixed>|null $params Bound parameters
+     */
+    public function execute(string $text, ?array $params = null): GraphResult
+    {
+        return $this->query($text, $params);
+    }
+
+    // -- portable node/edge/traverse core (Cypher) -------------------------
+
+    public function addNode(string $label, ?array $properties = null): ?GraphNode
+    {
+        $cypher = 'CREATE (n:`' . $label . '` $props) '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($cypher, ['props' => new CypherMap($properties ?? [])]);
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function addEdge(mixed $fromId, mixed $toId, string $type, ?array $properties = null): ?GraphEdge
+    {
+        $cypher = 'MATCH (a), (b) WHERE id(a) = $from_id AND id(b) = $to_id '
+            . 'CREATE (a)-[e:`' . $type . '` $props]->(b) '
+            . 'RETURN id(e) AS id, type(e) AS type, id(a) AS f, id(b) AS t, properties(e) AS props';
+        $rows = $this->run($cypher, [
+            'from_id' => $fromId,
+            'to_id' => $toId,
+            'props' => new CypherMap($properties ?? []),
+        ]);
+
+        if (!isset($rows[0])) {
+            return null;
+        }
+        $row = $rows[0];
+
+        return new GraphEdge(
+            $row['id'] ?? null,
+            (string) ($row['type'] ?? $type),
+            $row['f'] ?? null,
+            $row['t'] ?? null,
+            $row['props'] ?? []
+        );
+    }
+
+    public function getNode(mixed $nodeId): ?GraphNode
+    {
+        $cypher = 'MATCH (n) WHERE id(n) = $id '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($cypher, ['id' => $nodeId]);
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function updateNode(mixed $nodeId, array $properties): ?GraphNode
+    {
+        $cypher = 'MATCH (n) WHERE id(n) = $id SET n += $props '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($cypher, ['id' => $nodeId, 'props' => new CypherMap($properties)]);
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function deleteNode(mixed $nodeId): bool
+    {
+        $this->run('MATCH (n) WHERE id(n) = $id DETACH DELETE n', ['id' => $nodeId]);
+
+        return true;
+    }
+
+    public function neighbors(mixed $nodeId, string $direction = 'both', ?string $edgeType = null, int $limit = 100): array
+    {
+        $edge = $edgeType !== null ? ':`' . $edgeType . '`' : '';
+        $pattern = match ($direction) {
+            'out' => '(n)-[' . $edge . ']->(m)',
+            'in' => '(n)<-[' . $edge . ']-(m)',
+            default => '(n)-[' . $edge . ']-(m)',
+        };
+        $cypher = 'MATCH ' . $pattern . ' WHERE id(n) = $id '
+            . 'RETURN DISTINCT id(m) AS id, labels(m) AS labels, properties(m) AS props '
+            . 'LIMIT ' . (int) $limit;
+        $rows = $this->run($cypher, ['id' => $nodeId]);
+
+        return array_map(fn (array $row): ?GraphNode => $this->nodeFromRow($row), $rows);
+    }
+
+    public function traverse(mixed $startId, int $depth = 1, string $direction = 'both', ?string $edgeType = null, int $limit = 1000): array
+    {
+        // Cypher variable-length path `[*1..N]` — Neo4j AND Memgraph.
+        $edge = $edgeType !== null ? ':`' . $edgeType . '`' : '';
+        $quant = '*1..' . (int) $depth;
+        $pattern = match ($direction) {
+            'out' => '(n)-[' . $edge . $quant . ']->(m)',
+            'in' => '(n)<-[' . $edge . $quant . ']-(m)',
+            default => '(n)-[' . $edge . $quant . ']-(m)',
+        };
+        $cypher = 'MATCH ' . $pattern . ' WHERE id(n) = $start '
+            . 'RETURN DISTINCT id(m) AS id, labels(m) AS labels, properties(m) AS props '
+            . 'LIMIT ' . (int) $limit;
+        $rows = $this->run($cypher, ['start' => $startId]);
+
+        return array_map(fn (array $row): ?GraphNode => $this->nodeFromRow($row), $rows);
+    }
+
+    public function close(): void
+    {
+        // The laudis client holds pooled sockets closed on destruction; there is no
+        // explicit close on the client surface, so dropping the reference suffices.
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    /**
+     * A Bolt session bound to the target database (default when the URL omits one).
+     */
+    private function session(): object
+    {
+        $config = SessionConfiguration::default();
+        if ($this->database !== null && $this->database !== '') {
+            $config = $config->withDatabase($this->database);
+        }
+
+        return $this->client->getDriver('bolt')->createSession($config);
+    }
+
+    /**
+     * Recursively convert a laudis CypherMap/CypherList (or nested structure) into
+     * plain PHP arrays/scalars, so a GraphNode/GraphResult never holds driver types.
+     *
+     * @param mixed $value A driver value (CypherMap, CypherList, scalar, or array)
+     * @return mixed The plain PHP equivalent
+     */
+    private function toPlain(mixed $value): mixed
+    {
+        if (is_object($value) && method_exists($value, 'toArray')) {
+            $value = $value->toArray();
+        }
+        if (is_array($value)) {
+            return array_map(fn (mixed $item): mixed => $this->toPlain($item), $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Build a GraphNode from an id/labels/props result row.
+     *
+     * @param array<string, mixed>|null $row
+     */
+    private function nodeFromRow(?array $row): ?GraphNode
+    {
+        if ($row === null) {
+            return null;
+        }
+
+        /** @var array<int, string> $labels */
+        $labels = $row['labels'] ?? [];
+        /** @var array<string, mixed> $props */
+        $props = $row['props'] ?? [];
+
+        return new GraphNode($row['id'] ?? null, $labels, $props);
+    }
+
+    /**
+     * Whether a thrown error looks like an unreachable-host/connect failure rather
+     * than a query error, so it maps to GraphConnectTimeout.
+     *
+     * @param \Throwable $exception The caught error
+     */
+    private function looksLikeConnectFailure(\Throwable $exception): bool
+    {
+        $message = strtolower($exception->getMessage());
+        foreach (['timed out', 'timeout', 'connection', 'could not connect', 'no connection', 'unreachable', 'refused'] as $needle) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Tina4/Graph/GraphAdapter.php
+++ b/Tina4/Graph/GraphAdapter.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * The one surface every graph engine implements — the GraphAdapter contract.
+ *
+ * Mirrors the relational DatabaseAdapter, but is an ABSTRACT CLASS rather than a
+ * bare interface (matching the Python master): each method is a RAISING STUB, so
+ * a driver that does not override one fails LOUDLY, naming itself and the method,
+ * instead of silently doing nothing. Method names use PHP camelCase and map 1:1
+ * to Python's snake_case (addNode -> add_node, getError -> get_error).
+ *
+ * The portable core (addNode/addEdge/getNode/updateNode/deleteNode/neighbors/
+ * traverse) returns engine-neutral GraphNode/GraphEdge; the raw pass-through
+ * (query/execute) sends the engine's native dialect and returns a GraphResult.
+ */
+abstract class GraphAdapter
+{
+    /** Cause of the last failed operation, or null. */
+    protected ?string $lastError = null;
+
+    // -- portable node/edge/traverse core ----------------------------------
+
+    /**
+     * Create a vertex and return the stored GraphNode.
+     *
+     * @param string $label The node label
+     * @param array<string, mixed>|null $properties The node properties
+     * @return GraphNode|null The created node, or null if nothing was returned
+     */
+    public function addNode(string $label, ?array $properties = null): ?GraphNode
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement addNode');
+    }
+
+    /**
+     * Link two existing nodes and return the stored GraphEdge.
+     *
+     * @param mixed $fromId The source node id
+     * @param mixed $toId The target node id
+     * @param string $type The edge type/label
+     * @param array<string, mixed>|null $properties The edge properties
+     * @return GraphEdge|null The created edge, or null if nothing was returned
+     */
+    public function addEdge(mixed $fromId, mixed $toId, string $type, ?array $properties = null): ?GraphEdge
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement addEdge');
+    }
+
+    /**
+     * Return the stored GraphNode for an id, or null for a miss (not an error).
+     *
+     * @param mixed $nodeId The node id
+     * @return GraphNode|null
+     */
+    public function getNode(mixed $nodeId): ?GraphNode
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement getNode');
+    }
+
+    /**
+     * Merge properties into a node and return the updated GraphNode.
+     *
+     * @param mixed $nodeId The node id
+     * @param array<string, mixed> $properties The properties to merge
+     * @return GraphNode|null
+     */
+    public function updateNode(mixed $nodeId, array $properties): ?GraphNode
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement updateNode');
+    }
+
+    /**
+     * Remove a node (and its edges).
+     *
+     * @param mixed $nodeId The node id
+     * @return bool True on success
+     */
+    public function deleteNode(mixed $nodeId): bool
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement deleteNode');
+    }
+
+    /**
+     * Return the directly-connected nodes for a direction and optional edge type.
+     *
+     * @param mixed $nodeId The node id
+     * @param string $direction One of "out", "in", "both"
+     * @param string|null $edgeType Optional edge type filter
+     * @param int $limit Max nodes to return
+     * @return array<int, GraphNode>
+     */
+    public function neighbors(mixed $nodeId, string $direction = 'both', ?string $edgeType = null, int $limit = 100): array
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement neighbors');
+    }
+
+    /**
+     * Return the nodes reachable within `depth` hops from the start.
+     *
+     * @param mixed $startId The start node id
+     * @param int $depth Max hops
+     * @param string $direction One of "out", "in", "both"
+     * @param string|null $edgeType Optional edge type filter
+     * @param int $limit Max nodes to return
+     * @return array<int, GraphNode>
+     */
+    public function traverse(mixed $startId, int $depth = 1, string $direction = 'both', ?string $edgeType = null, int $limit = 1000): array
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement traverse');
+    }
+
+    // -- raw pass-through (engine-native dialect) --------------------------
+
+    /**
+     * Run a read in the engine's native language with bound params.
+     *
+     * @param string $text The engine's native read statement (GQL/Cypher/AQL)
+     * @param array<string, mixed>|null $params Bound parameters
+     * @return GraphResult
+     */
+    public function query(string $text, ?array $params = null): GraphResult
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement query');
+    }
+
+    /**
+     * Run a write in the engine's native language with bound params.
+     *
+     * @param string $text The engine's native write statement (GQL/Cypher/AQL)
+     * @param array<string, mixed>|null $params Bound parameters
+     * @return GraphResult
+     */
+    public function execute(string $text, ?array $params = null): GraphResult
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement execute');
+    }
+
+    // -- lifecycle ---------------------------------------------------------
+
+    /**
+     * Release the connection.
+     */
+    public function close(): void
+    {
+        throw new \BadMethodCallException(static::class . ' does not implement close');
+    }
+
+    /**
+     * Cause of the last failed operation, or null.
+     */
+    public function getError(): ?string
+    {
+        return $this->lastError;
+    }
+}

--- a/Tina4/Graph/GraphConnectTimeout.php
+++ b/Tina4/Graph/GraphConnectTimeout.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * A graph connect exceeded TINA4_GRAPH_CONNECT_TIMEOUT.
+ *
+ * The sibling of the relational connect-timeout contract
+ * (TINA4_DATABASE_CONNECT_TIMEOUT): an unbounded graph connect hangs the app with
+ * no signal, so a connect to an unreachable host raises this within the bound,
+ * naming the host, port and elapsed seconds.
+ *
+ * It is deliberately NOT a subclass of GraphError, so a caller can distinguish a
+ * connect timeout from a statement error — the same split as the Python master
+ * (GraphConnectTimeout is a TimeoutError, GraphError is not).
+ */
+class GraphConnectTimeout extends \RuntimeException
+{
+    /** The env var that bounds a graph connect. */
+    public const TIMEOUT_VARIABLE = 'TINA4_GRAPH_CONNECT_TIMEOUT';
+
+    /** Seconds a graph connect may block when the env var is unset. */
+    public const DEFAULT_TIMEOUT_SECONDS = 10.0;
+
+    /**
+     * Resolve TINA4_GRAPH_CONNECT_TIMEOUT to seconds.
+     *
+     * Mirrors the relational resolver: a value <= 0 disables the bound (returns
+     * null — unbounded), an unset var uses the default, and a non-numeric value
+     * warns and falls back to the default rather than waiting forever.
+     *
+     * @return float|null Seconds to bound the connect, or null for unbounded (<= 0)
+     */
+    public static function resolveSeconds(): ?float
+    {
+        $raw = trim((string) \Tina4\DotEnv::getEnv(self::TIMEOUT_VARIABLE));
+
+        if ($raw === '') {
+            return self::DEFAULT_TIMEOUT_SECONDS;
+        }
+
+        if (!is_numeric($raw)) {
+            \Tina4\Log::warning(
+                self::TIMEOUT_VARIABLE . "='{$raw}' is not a number of seconds — bounding graph "
+                . 'connects at the ' . self::DEFAULT_TIMEOUT_SECONDS . 's default instead'
+            );
+            return self::DEFAULT_TIMEOUT_SECONDS;
+        }
+
+        $seconds = (float) $raw;
+
+        return $seconds <= 0 ? null : $seconds;
+    }
+}

--- a/Tina4/Graph/GraphDatabase.php
+++ b/Tina4/Graph/GraphDatabase.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * URL-selected graph factory — the GraphDatabase sibling of Database.
+ *
+ * `GraphDatabase::create($url)` parses the scheme, picks the engine adapter and
+ * connects lazily; the engine driver is referenced only inside the adapter (first
+ * use of that engine), so referencing Tina4\Graph pulls in NO engine driver — the
+ * zero-dependency-core rule. A missing driver raises an actionable install error
+ * naming the composer package and command, never a bare "class not found".
+ */
+class GraphDatabase
+{
+    /**
+     * The default engine => [adapter class, composer package, install command]
+     * registrations. `bolt` (Neo4j/Memgraph) and `arango` land later — GraphUrl
+     * already resolves their schemes, so create() gives a clear "no adapter yet"
+     * message rather than a scheme-not-supported error.
+     *
+     * @var array<string, array{0: string, 1: string, 2: string}>
+     */
+    private const DEFAULT_ENGINE_ADAPTERS = [
+        'ultipa' => [
+            UltipaGraphAdapter::class,
+            'tina4stack/ultipa',
+            'composer require tina4stack/ultipa',
+        ],
+    ];
+
+    /**
+     * The live registry, seeded lazily from the default. Mutable so a new engine
+     * adapter can register itself (and so the driver-optional test can simulate an
+     * absent driver — the exact seam the Python master's _ENGINE_ADAPTERS provides).
+     *
+     * @var array<string, array{0: string, 1: string, 2: string}>|null
+     */
+    private static ?array $engineAdapters = null;
+
+    /**
+     * Parse the URL, pick the engine adapter, and connect lazily.
+     *
+     * @param string $url The graph connection URL (scheme selects the engine)
+     * @param string $username Fallback username when the URL omits credentials
+     * @param string $password Fallback password when the URL omits credentials
+     * @return GraphAdapter A connected adapter for the engine
+     * @throws \InvalidArgumentException When the URL scheme is not a graph engine
+     * @throws GraphError When no adapter exists for the engine, or its driver is not installed
+     */
+    public static function create(string $url, string $username = '', string $password = ''): GraphAdapter
+    {
+        $graphUrl = new GraphUrl($url);
+
+        $registry = self::engineAdapters();
+        $registration = $registry[$graphUrl->engine] ?? null;
+        if ($registration === null) {
+            $available = array_keys($registry);
+            sort($available);
+            throw new GraphError(
+                "No graph adapter for engine '{$graphUrl->engine}' yet "
+                . "(scheme '{$graphUrl->scheme}'). Available: " . implode(', ', $available) . '.'
+            );
+        }
+
+        [$adapterClass, $package, $installCommand] = $registration;
+
+        // The adapter's constructor references the engine driver
+        // (Tina4\Ultipa\Client). A missing driver surfaces as an Error the
+        // autoloader raises when that class can't be found — turn it into an
+        // actionable install error, exactly like the Python factory.
+        try {
+            return new $adapterClass($graphUrl, $username, $password);
+        } catch (\Error $exception) {
+            if (self::isMissingDriver($exception, $adapterClass)) {
+                throw new GraphError(
+                    "The graph driver for '{$graphUrl->engine}' is not installed ({$package}). "
+                    . "Install it with:\n    {$installCommand}",
+                    0,
+                    $exception
+                );
+            }
+            throw $exception;
+        }
+    }
+
+    /**
+     * Build from TINA4_GRAPH_URL (plus TINA4_GRAPH_USERNAME/_PASSWORD).
+     *
+     * @param string $envKey The environment variable holding the URL
+     * @return GraphAdapter|null Null when the env var is not set
+     * @throws \InvalidArgumentException When the URL scheme is not a graph engine
+     * @throws GraphError When the engine driver is not installed
+     */
+    public static function fromEnv(string $envKey = 'TINA4_GRAPH_URL'): ?GraphAdapter
+    {
+        $url = \Tina4\DotEnv::getEnv($envKey);
+        if ($url === null || $url === '') {
+            return null;
+        }
+
+        $username = (string) (\Tina4\DotEnv::getEnv('TINA4_GRAPH_USERNAME') ?? '');
+        $password = (string) (\Tina4\DotEnv::getEnv('TINA4_GRAPH_PASSWORD') ?? '');
+
+        return self::create($url, $username, $password);
+    }
+
+    /**
+     * Register (or replace) the adapter for an engine.
+     *
+     * Called by a new engine adapter to make itself selectable, and by the
+     * driver-optional test to point an engine at an absent driver. Passing null
+     * for $adapterClass restores the built-in default for that engine (or removes
+     * it if there is none), so a test can cleanly undo an override.
+     *
+     * @param string $engine The canonical engine name (e.g. "ultipa", "bolt")
+     * @param string|null $adapterClass The adapter class, or null to restore the default
+     * @param string $package The composer package that supplies the driver
+     * @param string $installCommand The command that installs it
+     */
+    public static function registerEngine(
+        string $engine,
+        ?string $adapterClass = null,
+        string $package = '',
+        string $installCommand = ''
+    ): void {
+        $registry = self::engineAdapters();
+
+        if ($adapterClass === null) {
+            if (isset(self::DEFAULT_ENGINE_ADAPTERS[$engine])) {
+                $registry[$engine] = self::DEFAULT_ENGINE_ADAPTERS[$engine];
+            } else {
+                unset($registry[$engine]);
+            }
+        } else {
+            $registry[$engine] = [$adapterClass, $package, $installCommand];
+        }
+
+        self::$engineAdapters = $registry;
+    }
+
+    /**
+     * The live engine registry, seeded from the default on first use.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    private static function engineAdapters(): array
+    {
+        return self::$engineAdapters ??= self::DEFAULT_ENGINE_ADAPTERS;
+    }
+
+    /**
+     * Whether an Error was raised because the engine driver class is absent
+     * (autoload could not find it), as opposed to some other runtime error or a
+     * framework autoload bug on the adapter class itself.
+     *
+     * @param \Error $exception The caught error
+     * @param string $adapterClass The adapter class being constructed
+     */
+    private static function isMissingDriver(\Error $exception, string $adapterClass): bool
+    {
+        // A missing driver class surfaces as "Class \"Tina4\Ultipa\Client\" not
+        // found". If the adapter class ITSELF is what's not found, that is a
+        // framework autoload problem, not a missing optional driver — let it fly.
+        $message = $exception->getMessage();
+        if (!str_contains($message, 'not found')) {
+            return false;
+        }
+
+        return !str_contains($message, $adapterClass);
+    }
+}

--- a/Tina4/Graph/GraphDatabase.php
+++ b/Tina4/Graph/GraphDatabase.php
@@ -21,9 +21,10 @@ class GraphDatabase
 {
     /**
      * The default engine => [adapter class, composer package, install command]
-     * registrations. `bolt` (Neo4j/Memgraph) and `arango` land later — GraphUrl
-     * already resolves their schemes, so create() gives a clear "no adapter yet"
-     * message rather than a scheme-not-supported error.
+     * registrations. `bolt` serves BOTH Neo4j and Memgraph (one Bolt/Cypher
+     * driver); `arango` serves ArangoDB. Each engine driver is an OPTIONAL
+     * community package, referenced only inside its adapter, so a missing driver
+     * surfaces as an actionable install error rather than a bare "class not found".
      *
      * @var array<string, array{0: string, 1: string, 2: string}>
      */
@@ -32,6 +33,16 @@ class GraphDatabase
             UltipaGraphAdapter::class,
             'tina4stack/ultipa',
             'composer require tina4stack/ultipa',
+        ],
+        'bolt' => [
+            BoltGraphAdapter::class,
+            'laudis/neo4j-php-client',
+            'composer require laudis/neo4j-php-client',
+        ],
+        'arango' => [
+            ArangoGraphAdapter::class,
+            'triagens/arangodb',
+            'composer require triagens/arangodb',
         ],
     ];
 

--- a/Tina4/Graph/GraphEdge.php
+++ b/Tina4/Graph/GraphEdge.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * Engine-neutral edge: id, type, from/to node ids, properties.
+ *
+ * `$fromId`/`$toId` are the ids of the endpoint nodes; `toArray()` emits them
+ * under the neutral `from`/`to` keys, the same shape on every engine.
+ */
+class GraphEdge implements \JsonSerializable
+{
+    /** @var mixed The engine's own edge id. */
+    public mixed $id;
+
+    public string $type;
+
+    /** @var mixed The id of the source node. */
+    public mixed $fromId;
+
+    /** @var mixed The id of the target node. */
+    public mixed $toId;
+
+    /** @var array<string, mixed> */
+    public array $properties;
+
+    /**
+     * @param mixed $id The engine's own edge id
+     * @param string $type The edge type/label
+     * @param mixed $fromId The source node id
+     * @param mixed $toId The target node id
+     * @param array<string, mixed>|null $properties Edge properties
+     */
+    public function __construct(mixed $id, string $type, mixed $fromId, mixed $toId, ?array $properties = null)
+    {
+        $this->id = $id;
+        $this->type = $type;
+        $this->fromId = $fromId;
+        $this->toId = $toId;
+        $this->properties = $properties ?? [];
+    }
+
+    /**
+     * @return array{id: mixed, type: string, from: mixed, to: mixed, properties: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'from' => $this->fromId,
+            'to' => $this->toId,
+            'properties' => $this->properties,
+        ];
+    }
+
+    /**
+     * @return array{id: mixed, type: string, from: mixed, to: mixed, properties: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/Tina4/Graph/GraphError.php
+++ b/Tina4/Graph/GraphError.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * A graph operation failed (a bad statement, an engine error, or a missing
+ * driver).
+ *
+ * The graph analogue of DatabaseException: writes and reads FAIL LOUD (raise on a
+ * bad statement) rather than returning a falsy value the caller might miss. The
+ * cause is also captured on the adapter's getError().
+ */
+class GraphError extends \RuntimeException
+{
+}

--- a/Tina4/Graph/GraphNode.php
+++ b/Tina4/Graph/GraphNode.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * Engine-neutral vertex: id, labels, properties.
+ *
+ * The graph analogue of a relational row — the same shape on every engine, so an
+ * app never sees engine-specific node objects. Node ids are echoed back exactly
+ * as the engine returns them (a UUID string on Ultipa); no type is assumed.
+ */
+class GraphNode implements \JsonSerializable
+{
+    /** @var mixed The engine's own node id. */
+    public mixed $id;
+
+    /** @var array<int, string> */
+    public array $labels;
+
+    /** @var array<string, mixed> */
+    public array $properties;
+
+    /**
+     * @param mixed $id The engine's own node id
+     * @param array<int, string>|null $labels Node labels
+     * @param array<string, mixed>|null $properties Node properties
+     */
+    public function __construct(mixed $id, ?array $labels = null, ?array $properties = null)
+    {
+        $this->id = $id;
+        $this->labels = array_values($labels ?? []);
+        $this->properties = $properties ?? [];
+    }
+
+    /**
+     * @return array{id: mixed, labels: array<int, string>, properties: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return ['id' => $this->id, 'labels' => $this->labels, 'properties' => $this->properties];
+    }
+
+    /**
+     * @return array{id: mixed, labels: array<int, string>, properties: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/Tina4/Graph/GraphResult.php
+++ b/Tina4/Graph/GraphResult.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * A raw-query result — records + columns, the same shape as the relational
+ * DatabaseResult. Iterable and countable, so `foreach ($result as $row)` yields
+ * the associative records directly.
+ */
+class GraphResult implements \IteratorAggregate, \Countable, \JsonSerializable
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $records;
+
+    /** @var array<int, string> */
+    public array $columns;
+
+    /**
+     * @param array<int, array<string, mixed>>|null $records Associative rows
+     * @param array<int, string>|null $columns Column names
+     */
+    public function __construct(?array $records = null, ?array $columns = null)
+    {
+        $this->records = array_values($records ?? []);
+        $this->columns = array_values($columns ?? []);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * The first cell of the first record, or null.
+     *
+     * @return mixed
+     */
+    public function scalar(): mixed
+    {
+        if ($this->records === []) {
+            return null;
+        }
+        $first = $this->records[0];
+
+        return $first === [] ? null : reset($first);
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->records);
+    }
+
+    public function count(): int
+    {
+        return count($this->records);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->records;
+    }
+}

--- a/Tina4/Graph/GraphUrl.php
+++ b/Tina4/Graph/GraphUrl.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+/**
+ * Parses a graph connection URL into its parts — the DatabaseUrl sibling for
+ * graph engines.
+ *
+ * Engine is the CANONICAL name the factory selects an adapter by; a scheme alias
+ * resolves to its engine here. `bolt`/`neo4j`/`memgraph` all speak Bolt/Cypher and
+ * share ONE adapter ("bolt"); the engine label only tunes per-engine defaults.
+ *
+ *   ultipa://user:pass@host:60061/mygraph
+ *   ultipas://host/mygraph        (TLS variant)
+ *   neo4j://host/db               (engine: bolt)
+ *   arango://host/db              (engine: arango)
+ */
+class GraphUrl
+{
+    /** @var array<string, string> URL scheme to CANONICAL engine name. */
+    private const SCHEME_ENGINE = [
+        'ultipa' => 'ultipa',
+        'ultipas' => 'ultipa',   // TLS variant
+        'neo4j' => 'bolt',
+        'neo4j+s' => 'bolt',
+        'bolt' => 'bolt',
+        'bolt+s' => 'bolt',
+        'memgraph' => 'bolt',
+        'arango' => 'arango',
+        'arangodb' => 'arango',
+    ];
+
+    /** @var array<string, int> Default port per engine when the URL omits one. */
+    private const ENGINE_DEFAULT_PORT = [
+        'ultipa' => 60061,
+        'bolt' => 7687,
+        'arango' => 8529,
+    ];
+
+    /** The raw URL as supplied. */
+    public readonly string $raw;
+
+    /** The raw scheme, lowercased (e.g. "ultipa", "ultipas", "neo4j"). */
+    public readonly string $scheme;
+
+    /** The canonical engine name: ultipa, bolt or arango. */
+    public readonly string $engine;
+
+    public readonly string $host;
+
+    /** The engine default applies when the URL omits a port. */
+    public readonly ?int $port;
+
+    /** The graph/database name (leading slash stripped), or null when absent. */
+    public readonly ?string $graph;
+
+    /** Null when absent, never an empty string — absent and blank are different. */
+    public readonly ?string $username;
+    public readonly ?string $password;
+
+    /** @var array<string, string> Query-string params. */
+    public readonly array $params;
+
+    /** True when the scheme ends in "s" (…s) or ?tls=1|true. */
+    public readonly bool $useTls;
+
+    /**
+     * Parse a graph connection URL.
+     *
+     * @param string $url The graph URL to parse
+     * @throws \InvalidArgumentException When the scheme is not a supported graph engine
+     */
+    public function __construct(string $url)
+    {
+        $this->raw = $url;
+        $parts = parse_url($url);
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        if (!isset(self::SCHEME_ENGINE[$scheme])) {
+            $supported = array_keys(self::SCHEME_ENGINE);
+            sort($supported);
+            throw new \InvalidArgumentException(
+                "Unsupported graph URL scheme '{$scheme}'. Supported: "
+                . implode(', ', $supported)
+                . ' (e.g. ultipa://host:60061/mygraph).'
+            );
+        }
+
+        $this->scheme = $scheme;
+        $this->engine = self::SCHEME_ENGINE[$scheme];
+        $this->host = $parts['host'] ?? 'localhost';
+        $this->port = $parts['port'] ?? (self::ENGINE_DEFAULT_PORT[$this->engine] ?? null);
+
+        // The path is the graph/database name (leading slash stripped).
+        $path = isset($parts['path']) ? ltrim($parts['path'], '/') : '';
+        $this->graph = $path !== '' ? $path : null;
+
+        $this->username = isset($parts['user']) ? urldecode($parts['user']) : null;
+        $this->password = isset($parts['pass']) ? urldecode($parts['pass']) : null;
+
+        $params = [];
+        if (isset($parts['query'])) {
+            parse_str($parts['query'], $params);
+        }
+        /** @var array<string, string> $params */
+        $this->params = $params;
+
+        $this->useTls = str_ends_with($scheme, 's')
+            || in_array((string) ($params['tls'] ?? ''), ['1', 'true'], true);
+    }
+
+    /**
+     * A DSN-style host:port/graph for messages — never carrying credentials.
+     */
+    public function getDsn(): string
+    {
+        $target = $this->port !== null ? "{$this->host}:{$this->port}" : $this->host;
+
+        return $this->graph !== null ? "{$target}/{$this->graph}" : $target;
+    }
+
+    /**
+     * Build from an environment variable (default TINA4_GRAPH_URL).
+     *
+     * @param string $envKey The environment variable name
+     * @return self|null Null when the env var is not set
+     * @throws \InvalidArgumentException When the URL scheme is unsupported
+     */
+    public static function fromEnv(string $envKey = 'TINA4_GRAPH_URL'): ?self
+    {
+        $url = \Tina4\DotEnv::getEnv($envKey);
+
+        if ($url === null || $url === '') {
+            return null;
+        }
+
+        return new self($url);
+    }
+}

--- a/Tina4/Graph/UltipaGraphAdapter.php
+++ b/Tina4/Graph/UltipaGraphAdapter.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ */
+
+namespace Tina4\Graph;
+
+use Tina4\Ultipa\Client;
+use Tina4\Ultipa\ConnectError;
+use Tina4\Ultipa\Result;
+use Tina4\Ultipa\UltipaError;
+
+/**
+ * Ultipa graph adapter — the portable core built in GQL over the tina4stack/ultipa
+ * driver.
+ *
+ * The driver (`Tina4\Ultipa\Client`) is an OPTIONAL dependency, referenced only
+ * inside this class, so referencing Tina4\Graph stays driver-free. The portable
+ * node/edge/traverse surface is expressed in Ultipa GQL on top of the driver's
+ * query()/execute(); the raw query()/execute() send GQL straight through.
+ *
+ * GQL note: the exact statements are verified against the live Ultipa community
+ * edition on the lab (no mocks). Ultipa node ids are UUID strings and edge ids need
+ * EDGE_ID enabled on the graph; we echo back whatever id(n)/id(e) returns without
+ * assuming a type. READS go through query() (readOnly), WRITES through execute()
+ * (readOnly=false) — Ultipa rejects a write issued over a read-only request.
+ */
+class UltipaGraphAdapter extends GraphAdapter
+{
+    private GraphUrl $url;
+
+    private Client $client;
+
+    /**
+     * @param GraphUrl $graphUrl The parsed graph URL
+     * @param string $username Fallback username when the URL omits one
+     * @param string $password Fallback password when the URL omits one
+     */
+    public function __construct(GraphUrl $graphUrl, string $username = '', string $password = '')
+    {
+        $this->url = $graphUrl;
+
+        $timeout = GraphConnectTimeout::resolveSeconds();
+
+        $this->client = new Client(
+            host: $graphUrl->host,
+            port: $graphUrl->port ?? Client::DEFAULT_PORT,
+            username: $graphUrl->username ?? ($username !== '' ? $username : null),
+            password: $graphUrl->password ?? ($password !== '' ? $password : null),
+            graph: $graphUrl->graph,
+            // null (unbounded, <= 0) maps to the driver's own 0 == no bound, the
+            // same as the Python master's `resolve_graph_connect_timeout() or 0`.
+            connectTimeout: $timeout ?? 0.0,
+            useTls: $graphUrl->useTls,
+        );
+    }
+
+    // -- connection + raw pass-through -------------------------------------
+
+    /**
+     * Connect (bounded) then run one GQL statement, translating driver errors.
+     *
+     * @param string $gql The GQL statement
+     * @param array<string, mixed>|null $params Bound parameters
+     * @param bool $readOnly True for a read (query), false for a write (execute)
+     * @return Result The driver result
+     * @throws GraphConnectTimeout When the connect exceeds the bound
+     * @throws GraphError When the statement fails
+     */
+    private function run(string $gql, ?array $params, bool $readOnly): Result
+    {
+        try {
+            $this->client->connect();
+        } catch (ConnectError $exception) {
+            $this->lastError = $exception->getMessage();
+            throw new GraphConnectTimeout(
+                'Graph connect to ' . $this->url->host . ':' . $this->url->port . ' timed out after '
+                . sprintf('%.1f', $exception->elapsed) . 's (TINA4_GRAPH_CONNECT_TIMEOUT). '
+                . 'Raise TINA4_GRAPH_CONNECT_TIMEOUT if the server is simply slow, or set it to 0 '
+                . 'to wait indefinitely.',
+                0,
+                $exception
+            );
+        }
+
+        try {
+            return $this->client->query($gql, $params, null, $readOnly);
+        } catch (UltipaError $exception) {
+            $this->lastError = $exception->getMessage();
+            throw new GraphError($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * Run a raw GQL read with bound params and return a GraphResult.
+     *
+     * @param string $text The GQL read statement
+     * @param array<string, mixed>|null $params Bound parameters
+     */
+    public function query(string $text, ?array $params = null): GraphResult
+    {
+        $result = $this->run($text, $params, true);
+
+        return new GraphResult($result->dicts(), $result->columns);
+    }
+
+    /**
+     * Run a raw GQL write with bound params and return a GraphResult.
+     *
+     * @param string $text The GQL write statement
+     * @param array<string, mixed>|null $params Bound parameters
+     */
+    public function execute(string $text, ?array $params = null): GraphResult
+    {
+        $result = $this->run($text, $params, false);
+
+        return new GraphResult($result->dicts(), $result->columns);
+    }
+
+    // -- portable node/edge/traverse core (GQL) ----------------------------
+
+    public function addNode(string $label, ?array $properties = null): ?GraphNode
+    {
+        [$propMap, $params] = $this->propClause($properties);
+        $gql = 'INSERT (n:`' . $label . '` ' . $propMap . ') '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($gql, $params, false)->dicts();
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function addEdge(mixed $fromId, mixed $toId, string $type, ?array $properties = null): ?GraphEdge
+    {
+        // id(e) requires EDGE_ID enabled on the Ultipa graph
+        // (`ALTER GRAPH <g> SET EDGE_ID ENABLED`), a one-time per-graph setting.
+        [$propMap, $params] = $this->propClause($properties);
+        $params['from_id'] = $fromId;
+        $params['to_id'] = $toId;
+        $gql = 'MATCH (a), (b) WHERE id(a) = $from_id AND id(b) = $to_id '
+            . 'INSERT (a)-[e:`' . $type . '` ' . $propMap . ']->(b) '
+            . 'RETURN id(e) AS id, type(e) AS type, id(a) AS f, id(b) AS t, properties(e) AS props';
+        $rows = $this->run($gql, $params, false)->dicts();
+
+        if (!isset($rows[0])) {
+            return null;
+        }
+        $row = $rows[0];
+
+        return new GraphEdge(
+            $row['id'] ?? null,
+            (string) ($row['type'] ?? $type),
+            $row['f'] ?? null,
+            $row['t'] ?? null,
+            $row['props'] ?? []
+        );
+    }
+
+    public function getNode(mixed $nodeId): ?GraphNode
+    {
+        $gql = 'MATCH (n) WHERE id(n) = $id '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($gql, ['id' => $nodeId], true)->dicts();
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function updateNode(mixed $nodeId, array $properties): ?GraphNode
+    {
+        $sets = [];
+        $params = [];
+        foreach ($properties as $key => $value) {
+            $sets[] = 'n.' . $key . ' = $p_' . $key;
+            $params['p_' . $key] = $value;
+        }
+        $params['id'] = $nodeId;
+        $gql = 'MATCH (n) WHERE id(n) = $id SET ' . implode(', ', $sets) . ' '
+            . 'RETURN id(n) AS id, labels(n) AS labels, properties(n) AS props';
+        $rows = $this->run($gql, $params, false)->dicts();
+
+        return isset($rows[0]) ? $this->nodeFromRow($rows[0]) : null;
+    }
+
+    public function deleteNode(mixed $nodeId): bool
+    {
+        $gql = 'MATCH (n) WHERE id(n) = $id DETACH DELETE n';
+        $this->run($gql, ['id' => $nodeId], false);
+
+        return true;
+    }
+
+    public function neighbors(mixed $nodeId, string $direction = 'both', ?string $edgeType = null, int $limit = 100): array
+    {
+        $edge = $edgeType !== null ? ':`' . $edgeType . '`' : '';
+        $pattern = match ($direction) {
+            'out' => '(n)-[' . $edge . ']->(m)',
+            'in' => '(n)<-[' . $edge . ']-(m)',
+            default => '(n)-[' . $edge . ']-(m)',
+        };
+        $gql = 'MATCH ' . $pattern . ' WHERE id(n) = $id '
+            . 'RETURN DISTINCT id(m) AS id, labels(m) AS labels, properties(m) AS props '
+            . 'LIMIT ' . (int) $limit;
+        $rows = $this->run($gql, ['id' => $nodeId], true)->dicts();
+
+        return array_map(fn (array $row): ?GraphNode => $this->nodeFromRow($row), $rows);
+    }
+
+    public function traverse(mixed $startId, int $depth = 1, string $direction = 'both', ?string $edgeType = null, int $limit = 1000): array
+    {
+        // Ultipa GQL uses the ISO quantified-path form `-[]->{1,N}`, NOT Cypher's
+        // `-[*1..N]->` (a parse error on gqldb).
+        $edge = $edgeType !== null ? ':`' . $edgeType . '`' : '';
+        $quant = '{1,' . (int) $depth . '}';
+        $pattern = match ($direction) {
+            'out' => '(n)-[' . $edge . ']->' . $quant . '(m)',
+            'in' => '(n)<-[' . $edge . ']-' . $quant . '(m)',
+            default => '(n)-[' . $edge . ']-' . $quant . '(m)',
+        };
+        $gql = 'MATCH ' . $pattern . ' WHERE id(n) = $start '
+            . 'RETURN DISTINCT id(m) AS id, labels(m) AS labels, properties(m) AS props '
+            . 'LIMIT ' . (int) $limit;
+        $rows = $this->run($gql, ['start' => $startId], true)->dicts();
+
+        return array_map(fn (array $row): ?GraphNode => $this->nodeFromRow($row), $rows);
+    }
+
+    public function close(): void
+    {
+        $this->client->close();
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    /**
+     * Build a GQL property map `{k1: $p_k1, ...}` plus the bound param dict.
+     *
+     * Params are BOUND (never interpolated), matching the relational ?-placeholder
+     * rule. Keys are namespaced (`p_`) so they never collide with an id param.
+     *
+     * @param array<string, mixed>|null $properties
+     * @return array{0: string, 1: array<string, mixed>} The map clause and its params
+     */
+    private function propClause(?array $properties): array
+    {
+        $properties = $properties ?? [];
+        if ($properties === []) {
+            return ['{}', []];
+        }
+
+        $pairs = [];
+        $params = [];
+        foreach ($properties as $key => $value) {
+            $pairs[] = $key . ': $p_' . $key;
+            $params['p_' . $key] = $value;
+        }
+
+        return ['{' . implode(', ', $pairs) . '}', $params];
+    }
+
+    /**
+     * Build a GraphNode from an id/labels/props result row.
+     *
+     * @param array<string, mixed>|null $row
+     */
+    private function nodeFromRow(?array $row): ?GraphNode
+    {
+        if ($row === null) {
+            return null;
+        }
+
+        /** @var array<int, string> $labels */
+        $labels = $row['labels'] ?? [];
+        /** @var array<string, mixed> $props */
+        $props = $row['props'] ?? [];
+
+        return new GraphNode($row['id'] ?? null, $labels, $props);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
             "Tina4\\": "Tina4/",
             "Tina4\\Cache\\": "Tina4/Cache/",
             "Tina4\\Database\\": "Tina4/Database/",
+            "Tina4\\Graph\\": "Tina4/Graph/",
             "Tina4\\Middleware\\": "Tina4/Middleware/",
             "Tina4\\Queue\\": "Tina4/Queue/",
             "Tina4\\Session\\": "Tina4/Session/"
@@ -42,6 +43,7 @@
     ],
     "suggest": {
         "ext-openssl": "Enables the RS256 JWT algorithm, MQTT over TLS (mqtts://), and outbound HTTPS from Tina4\\Api (PHP's https:// stream wrapper is registered by this extension). JWT signing does NOT need it: HS256/HS384/HS512 use the built-in hash_hmac",
+        "tina4stack/ultipa": "Ultipa graph driver — loaded only for ultipa:// connections through the Tina4\\Graph layer (GraphDatabase::create). Needs ext-grpc",
         "ext-sqlite3": "Required for SQLite3 database support",
         "ext-pdo": "Required for MySQL/PostgreSQL/MSSQL database support",
         "ext-pgsql": "Required for PostgreSQL database support",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
     "suggest": {
         "ext-openssl": "Enables the RS256 JWT algorithm, MQTT over TLS (mqtts://), and outbound HTTPS from Tina4\\Api (PHP's https:// stream wrapper is registered by this extension). JWT signing does NOT need it: HS256/HS384/HS512 use the built-in hash_hmac",
         "tina4stack/ultipa": "Ultipa graph driver — loaded only for ultipa:// connections through the Tina4\\Graph layer (GraphDatabase::create). Needs ext-grpc",
+        "laudis/neo4j-php-client": "Bolt graph driver — loaded only for neo4j://, memgraph:// and bolt:// connections through the Tina4\\Graph layer (GraphDatabase::create). Pure PHP over sockets; serves both Neo4j and Memgraph",
+        "triagens/arangodb": "ArangoDB graph driver — loaded only for arango:// connections through the Tina4\\Graph layer (GraphDatabase::create). Pure PHP over HTTP",
         "ext-sqlite3": "Required for SQLite3 database support",
         "ext-pdo": "Required for MySQL/PostgreSQL/MSSQL database support",
         "ext-pgsql": "Required for PostgreSQL database support",

--- a/plan/graph-databases.md
+++ b/plan/graph-databases.md
@@ -16,13 +16,18 @@ lab.
 - [x] `TINA4_GRAPH_CONNECT_TIMEOUT` resolver (default 10; <=0 unbounded)
 - [x] `GraphDatabase::create` / `::fromEnv` (lazy driver, actionable install error)
 - [x] `UltipaGraphAdapter` wrapping `Tina4\Ultipa\Client` (GQL core, VERBATIM statements)
-- [x] `tests/GraphTest.php` — 11 contract cases, real/no-mock, gated on TINA4_TEST_ULTIPA_URL
-- [x] composer.json: `Tina4\Graph\` autoload + suggest `tina4stack/ultipa`
+- [x] `BoltGraphAdapter` wrapping `laudis/neo4j-php-client` (Cypher core, `[*1..N]`) — Neo4j AND Memgraph
+- [x] `ArangoGraphAdapter` wrapping `triagens/arangodb` (AQL core, tina4_nodes/tina4_edges collections)
+- [x] Register `bolt` + `arango` engines in `GraphDatabase::DEFAULT_ENGINE_ADAPTERS`
+- [x] `tests/GraphTest.php` — provider matrix (ultipa/neo4j/memgraph/arango), real/no-mock, per-engine raw+clean
+- [x] composer.json: `Tina4\Graph\` autoload + suggest `tina4stack/ultipa`, `laudis/neo4j-php-client`, `triagens/arangodb`
 
 ## Parity
 | Feature | Python | PHP | Ruby | Node |
 |---------|--------|-----|------|------|
-| graph layer | done | done | owed | owed |
+| graph layer (ultipa) | done | done | owed | owed |
+| graph layer (bolt: neo4j+memgraph) | done | done | owed | owed |
+| graph layer (arango) | done | done | owed | owed |
 
 ## Tests (real, no mocks, positive + negative — 11 cases matching Python)
 - [x] graph-connect-by-url (scheme->adapter, unknown scheme rejected)
@@ -38,17 +43,32 @@ lab.
 - [x] graph-connect-timeout (black-hole host throws GraphConnectTimeout naming host/port)
 
 ## Bugs
-- (none logged)
+- [x] Bolt: empty `$props` PHP array serialised as a Bolt List, not a Map — Neo4j/
+  Memgraph rejected `CREATE (…) $props` with "expected Map … but was List". Fixed by
+  binding `new Laudis\Neo4j\Types\CypherMap($props ?? [])` in addNode/addEdge/updateNode.
+- [x] Test: `assertNotEmpty($edge->id)` failed on Neo4j edge id `0` (a valid id). Changed
+  the node/edge id assertions to `assertNotNull` (matches the Python master's `is not None`).
 
 ## Commits
-- (this commit  Tina4/Graph + tests/GraphTest.php + composer autoload/suggest + plan note)
+- (prior 58ade52d  Tina4/Graph core + UltipaGraphAdapter + tests + composer autoload/suggest)
+- (this commit  BoltGraphAdapter + ArangoGraphAdapter + GraphDatabase engine registration +
+  provider-matrix GraphTest + composer suggest + plan note)
 
-## Proof
-- Lab: PHP 8.3.6 + ext-grpc 1.82, published `tina4stack/ultipa` v0.1.0, live Ultipa
-  `ultipa://admin:***@192.168.88.99:60071/default` (graph `default`, EDGE_ID on).
-- `vendor/bin/phpunit tests/GraphTest.php` => OK (12 tests, 45 assertions, 0 failures,
-  0 skipped). Unique label `T4GraphContractTestPhp`, cleaned before+after each test
-  (0 residual nodes verified).
-- Windows PHP 8.4.8 (driver absent): 2 driver-free cases pass, 10 skip cleanly.
+## Proof — Ultipa (prior)
+- Lab PHP 8.3.6 + ext-grpc, live Ultipa; 12 tests, 45 assertions, 0 failures, 0 skipped.
 
-## Status: Complete (PHP + engine Ultipa). Ruby/Node still owed (parity feature).
+## Proof — Bolt + Arango (this commit)
+- Lab PHP 8.3.6, staged work dir, `composer require laudis/neo4j-php-client:3.6.0
+  triagens/arangodb:3.8.0` (both pure-PHP over sockets/HTTP, no C extension).
+- Live: Neo4j `bolt://neo4j:***@192.168.88.99:7687`, Memgraph `bolt://192.168.88.99:7688`,
+  ArangoDB 3.12.10 `arango://root:***@192.168.88.99:8529/_system`.
+- `vendor/bin/phpunit tests/GraphTest.php` => 39 tests, 103 assertions, 0 failures.
+  Per engine: Neo4j 9/9, Memgraph 9/9, Arango 9/9 (1 ⚠ carrying the arango driver's own
+  PHP 8.3 deprecations — vendor code, not Tina4). 10 skips = the Ultipa engine (driver not
+  installed in this bolt/arango work dir) + the ultipa-only connect-timeout case.
+- Cypher/AQL statements are VERBATIM from the Python master; the List→Map bug proves the
+  matrix is a real gate (red before the CypherMap fix, green after). 0 residual nodes on
+  all three engines after the run (unique label `T4GraphContractTestPhp`, cleaned each test).
+- Windows PHP 8.4.8 (drivers absent): 2 driver-free cases pass, 37 skip cleanly, 0 deprecations.
+
+## Status: Complete (PHP + engines Ultipa, Neo4j, Memgraph, ArangoDB). Ruby/Node still owed.

--- a/plan/graph-databases.md
+++ b/plan/graph-databases.md
@@ -1,0 +1,54 @@
+# Task: Port the graph data layer (Feature 139) to PHP
+
+Outcome: `Tina4\Graph` mirrors `Tina4\Database` — a URL-selected graph factory,
+neutral node/edge/result shapes, a raising adapter contract, a connect-timeout
+resolver, and an Ultipa adapter wrapping the `tina4stack/ultipa` driver. Identical
+external behaviour to the PROVEN Python reference
+(`tina4-python/tina4_python/graph/`). Real no-mock tests against live Ultipa on the
+lab.
+
+## Scope
+- [x] Read Python reference + tests + ADR-0059/feature 139 + fixture
+- [x] Read PHP `Tina4/Database/` idiom + ultipa-php driver API
+- [x] `GraphUrl` (scheme->engine, default ports, TLS, creds, fromEnv)
+- [x] Neutral shapes `GraphNode` / `GraphEdge` / `GraphResult`
+- [x] `GraphAdapter` interface (raising stubs) + `GraphError` + `GraphConnectTimeout`
+- [x] `TINA4_GRAPH_CONNECT_TIMEOUT` resolver (default 10; <=0 unbounded)
+- [x] `GraphDatabase::create` / `::fromEnv` (lazy driver, actionable install error)
+- [x] `UltipaGraphAdapter` wrapping `Tina4\Ultipa\Client` (GQL core, VERBATIM statements)
+- [x] `tests/GraphTest.php` — 11 contract cases, real/no-mock, gated on TINA4_TEST_ULTIPA_URL
+- [x] composer.json: `Tina4\Graph\` autoload + suggest `tina4stack/ultipa`
+
+## Parity
+| Feature | Python | PHP | Ruby | Node |
+|---------|--------|-----|------|------|
+| graph layer | done | done | owed | owed |
+
+## Tests (real, no mocks, positive + negative — 11 cases matching Python)
+- [x] graph-connect-by-url (scheme->adapter, unknown scheme rejected)
+- [x] graph-add-node
+- [x] graph-add-edge
+- [x] graph-get-node (roundtrip + miss->null)
+- [x] graph-update-delete-node (merge, then remove)
+- [x] graph-neighbors (direction/edge-type filter, unmatched->empty)
+- [x] graph-traverse-depth (GQL quantified path {1,N})
+- [x] graph-raw-query (bound params)
+- [x] graph-write-fails-loud (bad GQL throws, getError set)
+- [x] graph-driver-optional (core loads driver-free; missing driver -> install error)
+- [x] graph-connect-timeout (black-hole host throws GraphConnectTimeout naming host/port)
+
+## Bugs
+- (none logged)
+
+## Commits
+- (this commit  Tina4/Graph + tests/GraphTest.php + composer autoload/suggest + plan note)
+
+## Proof
+- Lab: PHP 8.3.6 + ext-grpc 1.82, published `tina4stack/ultipa` v0.1.0, live Ultipa
+  `ultipa://admin:***@192.168.88.99:60071/default` (graph `default`, EDGE_ID on).
+- `vendor/bin/phpunit tests/GraphTest.php` => OK (12 tests, 45 assertions, 0 failures,
+  0 skipped). Unique label `T4GraphContractTestPhp`, cleaned before+after each test
+  (0 residual nodes verified).
+- Windows PHP 8.4.8 (driver absent): 2 driver-free cases pass, 10 skip cleanly.
+
+## Status: Complete (PHP + engine Ultipa). Ruby/Node still owed (parity feature).

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * Contract suite for the graph data layer (Feature 139) — against a REAL engine.
+ *
+ * No mocks. Every live case runs a real connection and real round-trips against a
+ * provisioned graph engine. Ultipa community edition is the first engine; the URL
+ * comes from TINA4_TEST_ULTIPA_URL (the live cases skip when it is unset/
+ * unreachable, exactly like the relational live-database tests). Case names match
+ * fixtures/graph_contract.json and the Python master (tests/test_graph.py).
+ *
+ * Ultipa note: edge ids need EDGE_ID enabled on the graph
+ * (`ALTER GRAPH <g> SET EDGE_ID ENABLED`) — a one-time per-graph setting the lab
+ * provisions.
+ */
+
+namespace Tina4;
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Graph\GraphAdapter;
+use Tina4\Graph\GraphConnectTimeout;
+use Tina4\Graph\GraphDatabase;
+use Tina4\Graph\GraphEdge;
+use Tina4\Graph\GraphError;
+use Tina4\Graph\GraphNode;
+use Tina4\Graph\GraphResult;
+use Tina4\Graph\GraphUrl;
+
+class GraphTest extends TestCase
+{
+    private const LABEL = 'T4GraphContractTestPhp';
+    private const DRIVER_CLASS = 'Tina4\\Ultipa\\Client';
+
+    private ?string $url = null;
+    private ?GraphAdapter $graph = null;
+
+    protected function setUp(): void
+    {
+        $env = getenv('TINA4_TEST_ULTIPA_URL');
+        $this->url = ($env === false || $env === '') ? null : $env;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->graph !== null) {
+            try {
+                $this->graph->execute('MATCH (n:`' . self::LABEL . '`) DETACH DELETE n');
+            } catch (\Throwable) {
+                // best-effort cleanup
+            }
+            $this->graph->close();
+            $this->graph = null;
+        }
+    }
+
+    // ── driver-optional + URL selection run WITHOUT a live engine ────────────
+
+    /**
+     * graph-driver-optional: the core loads with NO engine driver; opening a
+     * connection whose driver is absent raises an actionable install error naming
+     * the package and command.
+     */
+    public function testGraphDriverOptional(): void
+    {
+        // The core imports with no engine driver present.
+        foreach ([
+            GraphUrl::class, GraphNode::class, GraphEdge::class, GraphResult::class,
+            GraphAdapter::class, GraphDatabase::class, GraphConnectTimeout::class, GraphError::class,
+        ] as $coreClass) {
+            $this->assertTrue(class_exists($coreClass), "{$coreClass} must load driver-free");
+        }
+
+        // Point the ultipa engine at an adapter whose driver class is absent — the
+        // same seam the Python master uses by mutating _ENGINE_ADAPTERS. create()
+        // must surface the install error, not a bare "class not found".
+        GraphDatabase::registerEngine(
+            'ultipa',
+            AbsentDriverGraphAdapter::class,
+            'tina4stack/ultipa',
+            'composer require tina4stack/ultipa'
+        );
+        try {
+            $this->expectException(GraphError::class);
+            $this->expectExceptionMessage('tina4stack/ultipa');
+            GraphDatabase::create('ultipa://h:60061/g');
+        } finally {
+            GraphDatabase::registerEngine('ultipa');   // restore the real adapter
+        }
+    }
+
+    /**
+     * graph-connect-by-url: the URL scheme picks the adapter; an unknown scheme is
+     * rejected.
+     */
+    public function testGraphConnectByUrlSelectsAdapter(): void
+    {
+        $this->assertSame('ultipa', (new GraphUrl('ultipa://h:60061/g'))->engine);
+        $this->assertSame('bolt', (new GraphUrl('neo4j://h/db'))->engine);
+        $this->assertSame('arango', (new GraphUrl('arango://h/db'))->engine);
+
+        $this->expectException(\InvalidArgumentException::class);
+        new GraphUrl('mysql://h/db');
+    }
+
+    // ── the portable core + raw pass-through, against LIVE Ultipa ─────────────
+
+    public function testGraphConnectByUrlLive(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $this->assertSame('UltipaGraphAdapter', (new \ReflectionClass($graph))->getShortName());
+    }
+
+    public function testGraphAddNode(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $node = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
+        $this->assertInstanceOf(GraphNode::class, $node);
+        $this->assertNotEmpty($node->id);
+        $this->assertContains(self::LABEL, $node->labels);
+        $this->assertSame('Ada', $node->properties['name']);
+    }
+
+    public function testGraphAddEdge(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $a = $graph->addNode(self::LABEL, ['name' => 'Ada']);
+        $b = $graph->addNode(self::LABEL, ['name' => 'Bob']);
+        $edge = $graph->addEdge($a->id, $b->id, 'KNOWS', ['since' => 2020]);
+        $this->assertInstanceOf(GraphEdge::class, $edge);
+        $this->assertNotEmpty($edge->id);
+        $this->assertSame('KNOWS', $edge->type);
+        $this->assertSame($a->id, $edge->fromId);
+        $this->assertSame($b->id, $edge->toId);
+        $this->assertSame(2020, $edge->properties['since']);
+    }
+
+    public function testGraphGetNodeRoundtripAndMiss(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $a = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
+        $got = $graph->getNode($a->id);
+        $this->assertSame('Ada', $got->properties['name']);
+        $this->assertSame(36, $got->properties['age']);
+        // A miss is not an error.
+        $this->assertNull($graph->getNode('no-such-id'));
+    }
+
+    public function testGraphUpdateDeleteNode(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $a = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
+        $graph->updateNode($a->id, ['name' => 'Ada Lovelace', 'city' => 'London']);
+        $updated = $graph->getNode($a->id);
+        $this->assertSame('Ada Lovelace', $updated->properties['name']);
+        $this->assertSame('London', $updated->properties['city']);
+        $this->assertSame(36, $updated->properties['age']);   // merge, not replace
+        $graph->deleteNode($a->id);
+        $this->assertNull($graph->getNode($a->id));
+    }
+
+    public function testGraphNeighbors(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $a = $graph->addNode(self::LABEL, ['name' => 'Ada']);
+        $b = $graph->addNode(self::LABEL, ['name' => 'Bob']);
+        $graph->addEdge($a->id, $b->id, 'KNOWS', []);
+        $out = array_map(fn (GraphNode $n) => $n->id, $graph->neighbors($a->id, 'out', 'KNOWS'));
+        $this->assertContains($b->id, $out);
+        $this->assertNotContains($a->id, $out);
+        // An unmatched filter returns empty, not an error.
+        $this->assertSame([], $graph->neighbors($a->id, 'both', 'NOPE'));
+    }
+
+    public function testGraphTraverseDepth(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $a = $graph->addNode(self::LABEL, ['name' => 'A']);
+        $b = $graph->addNode(self::LABEL, ['name' => 'B']);
+        $c = $graph->addNode(self::LABEL, ['name' => 'C']);
+        $graph->addEdge($a->id, $b->id, 'KNOWS', []);
+        $graph->addEdge($b->id, $c->id, 'KNOWS', []);
+        $reached = array_map(fn (GraphNode $n) => $n->id, $graph->traverse($a->id, 2, 'out', 'KNOWS'));
+        $this->assertContains($b->id, $reached);   // 2 hops reach both
+        $this->assertContains($c->id, $reached);
+    }
+
+    public function testGraphRawQueryBoundParams(): void
+    {
+        $graph = $this->requireLiveGraph();
+        $graph->addNode(self::LABEL, ['name' => 'Bob']);
+        $result = $graph->query(
+            'MATCH (n:`' . self::LABEL . '`) WHERE n.name = $nm RETURN n.name AS name',
+            ['nm' => 'Bob']
+        );
+        $this->assertInstanceOf(GraphResult::class, $result);
+        $this->assertGreaterThanOrEqual(1, count($result));
+        $this->assertSame('Bob', $result->records[0]['name']);
+    }
+
+    public function testGraphWriteFailsLoud(): void
+    {
+        $graph = $this->requireLiveGraph();
+        try {
+            $graph->execute('THIS IS NOT GQL');
+            $this->fail('a bad raw statement must raise GraphError, never return');
+        } catch (GraphError) {
+            $this->assertNotNull($graph->getError());
+        }
+    }
+
+    /**
+     * graph-connect-timeout: an unreachable host throws GraphConnectTimeout within
+     * the bound, naming host and port (mirrors the relational connect-timeout
+     * contract). Uses a black-hole IP — no live server needed — but needs the
+     * driver + ext-grpc, so it skips when they are absent.
+     */
+    public function testGraphConnectTimeout(): void
+    {
+        if (!class_exists(self::DRIVER_CLASS)) {
+            $this->markTestSkipped('tina4stack/ultipa driver not installed');
+        }
+
+        putenv('TINA4_GRAPH_CONNECT_TIMEOUT=2');
+        $_ENV['TINA4_GRAPH_CONNECT_TIMEOUT'] = '2';
+        try {
+            $started = microtime(true);
+            try {
+                // 10.255.255.1 completes no handshake — a real black hole, not a refusal.
+                GraphDatabase::create('ultipa://admin:x@10.255.255.1:60071/default')->getNode('x');
+                $this->fail('an unreachable host must throw GraphConnectTimeout');
+            } catch (GraphConnectTimeout $exception) {
+                $elapsed = microtime(true) - $started;
+                $this->assertLessThan(6, $elapsed);
+                $this->assertStringContainsString('10.255.255.1', $exception->getMessage());
+                $this->assertStringContainsString('60071', $exception->getMessage());
+            }
+        } finally {
+            putenv('TINA4_GRAPH_CONNECT_TIMEOUT');
+            unset($_ENV['TINA4_GRAPH_CONNECT_TIMEOUT']);
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * A connected Ultipa adapter on a clean slate for the test label, or a skip
+     * when the live engine is not configured/reachable or the driver is absent.
+     */
+    private function requireLiveGraph(): GraphAdapter
+    {
+        if ($this->url === null || !$this->reachable($this->url)) {
+            $this->markTestSkipped('live Ultipa not configured/reachable (set TINA4_TEST_ULTIPA_URL)');
+        }
+        if (!class_exists(self::DRIVER_CLASS)) {
+            $this->markTestSkipped('tina4stack/ultipa driver not installed');
+        }
+
+        $graph = GraphDatabase::create($this->url);
+        $graph->execute('MATCH (n:`' . self::LABEL . '`) DETACH DELETE n');
+        $this->graph = $graph;
+
+        return $graph;
+    }
+
+    private function reachable(string $url): bool
+    {
+        $parts = parse_url($url);
+        $host = $parts['host'] ?? null;
+        $port = $parts['port'] ?? 60061;
+        if ($host === null) {
+            return false;
+        }
+        $socket = @fsockopen($host, (int) $port, $errno, $errstr, 2.0);
+        if ($socket === false) {
+            return false;
+        }
+        fclose($socket);
+
+        return true;
+    }
+}
+
+/**
+ * A GraphAdapter whose constructor references a driver class that does not exist,
+ * so GraphDatabase::create() must translate the resulting "class not found" Error
+ * into the actionable install error. The graph-driver-optional simulation.
+ */
+class AbsentDriverGraphAdapter extends GraphAdapter
+{
+    public function __construct(GraphUrl $graphUrl, string $username = '', string $password = '')
+    {
+        // This class is intentionally absent — instantiating it raises the same
+        // "Class ... not found" Error a genuinely-missing driver would.
+        new \Tina4\Ultipa\_DefinitelyAbsent\Driver();
+    }
+}

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -5,13 +5,19 @@
  * Copyright 2007 - current Tina4
  * License: MIT https://opensource.org/licenses/MIT
  *
- * Contract suite for the graph data layer (Feature 139) — against a REAL engine.
+ * Contract suite for the graph data layer (Feature 139) — against REAL engines.
  *
- * No mocks. Every live case runs a real connection and real round-trips against a
- * provisioned graph engine. Ultipa community edition is the first engine; the URL
- * comes from TINA4_TEST_ULTIPA_URL (the live cases skip when it is unset/
- * unreachable, exactly like the relational live-database tests). Case names match
- * fixtures/graph_contract.json and the Python master (tests/test_graph.py).
+ * No mocks. Every live case runs a real connection and real round-trips, and is
+ * PARAMETERISED over every provisioned engine (provider substitutability, exactly
+ * like the relational engine matrix): Ultipa, Neo4j, Memgraph, ArangoDB. Each
+ * engine's URL comes from its own TINA4_TEST_<ENGINE>_URL; an engine whose URL is
+ * unset/unreachable, or whose optional driver is not installed, is skipped. Case
+ * names match fixtures/graph_contract.json and the Python master
+ * (tina4-python/tests/test_graph.py).
+ *
+ * Only the raw-query dialect and the cleanup differ per engine (GQL/Cypher vs AQL)
+ * — the portable node/edge/traverse surface is identical everywhere, which is the
+ * whole point of the layer.
  *
  * Ultipa note: edge ids need EDGE_ID enabled on the graph
  * (`ALTER GRAPH <g> SET EDGE_ID ENABLED`) — a one-time per-graph setting the lab
@@ -20,6 +26,7 @@
 
 namespace Tina4;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Tina4\Graph\GraphAdapter;
 use Tina4\Graph\GraphConnectTimeout;
@@ -33,27 +40,79 @@ use Tina4\Graph\GraphUrl;
 class GraphTest extends TestCase
 {
     private const LABEL = 'T4GraphContractTestPhp';
-    private const DRIVER_CLASS = 'Tina4\\Ultipa\\Client';
+    private const ULTIPA_DRIVER_CLASS = 'Tina4\\Ultipa\\Client';
 
-    private ?string $url = null;
+    /** A Cypher/GQL read that finds a node by name, and its label cleanup. */
+    private const CYPHER_RAW = 'MATCH (n:`' . self::LABEL . '`) WHERE n.name = $nm RETURN n.name AS name';
+    private const CYPHER_CLEAN = 'MATCH (n:`' . self::LABEL . '`) DETACH DELETE n';
+
+    /** The AQL equivalents for Arango's document/collection model. */
+    private const AQL_RAW = 'FOR n IN tina4_nodes FILTER n.name == @nm RETURN {name: n.name}';
+    private const AQL_CLEAN = "FOR n IN tina4_nodes FILTER '" . self::LABEL . "' IN n._labels REMOVE n IN tina4_nodes";
+
     private ?GraphAdapter $graph = null;
+    private ?string $cleanStatement = null;
 
-    protected function setUp(): void
+    /**
+     * Per-engine wiring: the env var holding its URL, the optional driver class
+     * whose presence gates the live cases, and the native raw-read + cleanup
+     * statements (Cypher/GQL for ultipa/neo4j/memgraph, AQL for arango).
+     *
+     * @return array<string, array{env: string, driver: string, raw: string, clean: string}>
+     */
+    private static function engineConfig(): array
     {
-        $env = getenv('TINA4_TEST_ULTIPA_URL');
-        $this->url = ($env === false || $env === '') ? null : $env;
+        return [
+            'ultipa' => [
+                'env' => 'TINA4_TEST_ULTIPA_URL',
+                'driver' => self::ULTIPA_DRIVER_CLASS,
+                'raw' => self::CYPHER_RAW,
+                'clean' => self::CYPHER_CLEAN,
+            ],
+            'neo4j' => [
+                'env' => 'TINA4_TEST_NEO4J_URL',
+                'driver' => 'Laudis\\Neo4j\\ClientBuilder',
+                'raw' => self::CYPHER_RAW,
+                'clean' => self::CYPHER_CLEAN,
+            ],
+            'memgraph' => [
+                'env' => 'TINA4_TEST_MEMGRAPH_URL',
+                'driver' => 'Laudis\\Neo4j\\ClientBuilder',
+                'raw' => self::CYPHER_RAW,
+                'clean' => self::CYPHER_CLEAN,
+            ],
+            'arango' => [
+                'env' => 'TINA4_TEST_ARANGO_URL',
+                'driver' => 'ArangoDBClient\\Connection',
+                'raw' => self::AQL_RAW,
+                'clean' => self::AQL_CLEAN,
+            ],
+        ];
+    }
+
+    /**
+     * The engine names the live matrix runs over.
+     *
+     * @return array<int, array{0: string}>
+     */
+    public static function engines(): array
+    {
+        return array_map(static fn (string $name): array => [$name], array_keys(self::engineConfig()));
     }
 
     protected function tearDown(): void
     {
         if ($this->graph !== null) {
             try {
-                $this->graph->execute('MATCH (n:`' . self::LABEL . '`) DETACH DELETE n');
+                if ($this->cleanStatement !== null) {
+                    $this->graph->execute($this->cleanStatement);
+                }
             } catch (\Throwable) {
                 // best-effort cleanup
             }
             $this->graph->close();
             $this->graph = null;
+            $this->cleanStatement = null;
         }
     }
 
@@ -94,64 +153,74 @@ class GraphTest extends TestCase
 
     /**
      * graph-connect-by-url: the URL scheme picks the adapter; an unknown scheme is
-     * rejected.
+     * rejected. neo4j/memgraph/bolt all resolve to the single "bolt" engine.
      */
     public function testGraphConnectByUrlSelectsAdapter(): void
     {
         $this->assertSame('ultipa', (new GraphUrl('ultipa://h:60061/g'))->engine);
         $this->assertSame('bolt', (new GraphUrl('neo4j://h/db'))->engine);
+        $this->assertSame('bolt', (new GraphUrl('memgraph://h/db'))->engine);
+        $this->assertSame('bolt', (new GraphUrl('bolt://h/db'))->engine);
         $this->assertSame('arango', (new GraphUrl('arango://h/db'))->engine);
 
         $this->expectException(\InvalidArgumentException::class);
         new GraphUrl('mysql://h/db');
     }
 
-    // ── the portable core + raw pass-through, against LIVE Ultipa ─────────────
+    // ── the portable core + raw pass-through, per LIVE engine ────────────────
 
-    public function testGraphConnectByUrlLive(): void
+    #[DataProvider('engines')]
+    public function testGraphConnectByUrlLive(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
-        $this->assertSame('UltipaGraphAdapter', (new \ReflectionClass($graph))->getShortName());
+        $graph = $this->liveGraph($engine);
+        $this->assertInstanceOf(GraphAdapter::class, $graph);
     }
 
-    public function testGraphAddNode(): void
+    #[DataProvider('engines')]
+    public function testGraphAddNode(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $node = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
         $this->assertInstanceOf(GraphNode::class, $node);
-        $this->assertNotEmpty($node->id);
+        $this->assertNotNull($node->id);   // an integer 0 is a valid id (Neo4j/Memgraph)
         $this->assertContains(self::LABEL, $node->labels);
         $this->assertSame('Ada', $node->properties['name']);
+        $this->assertSame(36, $node->properties['age']);
     }
 
-    public function testGraphAddEdge(): void
+    #[DataProvider('engines')]
+    public function testGraphAddEdge(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $a = $graph->addNode(self::LABEL, ['name' => 'Ada']);
         $b = $graph->addNode(self::LABEL, ['name' => 'Bob']);
         $edge = $graph->addEdge($a->id, $b->id, 'KNOWS', ['since' => 2020]);
         $this->assertInstanceOf(GraphEdge::class, $edge);
-        $this->assertNotEmpty($edge->id);
+        $this->assertNotNull($edge->id);   // an integer 0 is a valid id (Neo4j/Memgraph)
         $this->assertSame('KNOWS', $edge->type);
         $this->assertSame($a->id, $edge->fromId);
         $this->assertSame($b->id, $edge->toId);
         $this->assertSame(2020, $edge->properties['since']);
     }
 
-    public function testGraphGetNodeRoundtripAndMiss(): void
+    #[DataProvider('engines')]
+    public function testGraphGetNodeRoundtripAndMiss(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $a = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
         $got = $graph->getNode($a->id);
         $this->assertSame('Ada', $got->properties['name']);
         $this->assertSame(36, $got->properties['age']);
-        // A miss is not an error.
-        $this->assertNull($graph->getNode('no-such-id'));
+        // A miss (a deleted id) is not an error.
+        $tmp = $graph->addNode(self::LABEL, ['x' => 1]);
+        $graph->deleteNode($tmp->id);
+        $this->assertNull($graph->getNode($tmp->id));
     }
 
-    public function testGraphUpdateDeleteNode(): void
+    #[DataProvider('engines')]
+    public function testGraphUpdateDeleteNode(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $a = $graph->addNode(self::LABEL, ['name' => 'Ada', 'age' => 36]);
         $graph->updateNode($a->id, ['name' => 'Ada Lovelace', 'city' => 'London']);
         $updated = $graph->getNode($a->id);
@@ -162,9 +231,10 @@ class GraphTest extends TestCase
         $this->assertNull($graph->getNode($a->id));
     }
 
-    public function testGraphNeighbors(): void
+    #[DataProvider('engines')]
+    public function testGraphNeighbors(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $a = $graph->addNode(self::LABEL, ['name' => 'Ada']);
         $b = $graph->addNode(self::LABEL, ['name' => 'Bob']);
         $graph->addEdge($a->id, $b->id, 'KNOWS', []);
@@ -175,9 +245,10 @@ class GraphTest extends TestCase
         $this->assertSame([], $graph->neighbors($a->id, 'both', 'NOPE'));
     }
 
-    public function testGraphTraverseDepth(): void
+    #[DataProvider('engines')]
+    public function testGraphTraverseDepth(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $a = $graph->addNode(self::LABEL, ['name' => 'A']);
         $b = $graph->addNode(self::LABEL, ['name' => 'B']);
         $c = $graph->addNode(self::LABEL, ['name' => 'C']);
@@ -188,24 +259,23 @@ class GraphTest extends TestCase
         $this->assertContains($c->id, $reached);
     }
 
-    public function testGraphRawQueryBoundParams(): void
+    #[DataProvider('engines')]
+    public function testGraphRawQueryBoundParams(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         $graph->addNode(self::LABEL, ['name' => 'Bob']);
-        $result = $graph->query(
-            'MATCH (n:`' . self::LABEL . '`) WHERE n.name = $nm RETURN n.name AS name',
-            ['nm' => 'Bob']
-        );
+        $result = $graph->query(self::engineConfig()[$engine]['raw'], ['nm' => 'Bob']);
         $this->assertInstanceOf(GraphResult::class, $result);
         $this->assertGreaterThanOrEqual(1, count($result));
         $this->assertSame('Bob', $result->records[0]['name']);
     }
 
-    public function testGraphWriteFailsLoud(): void
+    #[DataProvider('engines')]
+    public function testGraphWriteFailsLoud(string $engine): void
     {
-        $graph = $this->requireLiveGraph();
+        $graph = $this->liveGraph($engine);
         try {
-            $graph->execute('THIS IS NOT GQL');
+            $graph->execute('THIS IS NOT A VALID STATEMENT');
             $this->fail('a bad raw statement must raise GraphError, never return');
         } catch (GraphError) {
             $this->assertNotNull($graph->getError());
@@ -216,11 +286,11 @@ class GraphTest extends TestCase
      * graph-connect-timeout: an unreachable host throws GraphConnectTimeout within
      * the bound, naming host and port (mirrors the relational connect-timeout
      * contract). Uses a black-hole IP — no live server needed — but needs the
-     * driver + ext-grpc, so it skips when they are absent.
+     * Ultipa driver + ext-grpc, so it skips when they are absent.
      */
     public function testGraphConnectTimeout(): void
     {
-        if (!class_exists(self::DRIVER_CLASS)) {
+        if (!class_exists(self::ULTIPA_DRIVER_CLASS)) {
             $this->markTestSkipped('tina4stack/ultipa driver not installed');
         }
 
@@ -247,21 +317,28 @@ class GraphTest extends TestCase
     // ── helpers ──────────────────────────────────────────────────────────────
 
     /**
-     * A connected Ultipa adapter on a clean slate for the test label, or a skip
-     * when the live engine is not configured/reachable or the driver is absent.
+     * A connected adapter for the named engine on a clean slate for the test
+     * label, or a skip when its URL is unset/unreachable or its driver is absent.
+     *
+     * @param string $engine One of ultipa, neo4j, memgraph, arango
      */
-    private function requireLiveGraph(): GraphAdapter
+    private function liveGraph(string $engine): GraphAdapter
     {
-        if ($this->url === null || !$this->reachable($this->url)) {
-            $this->markTestSkipped('live Ultipa not configured/reachable (set TINA4_TEST_ULTIPA_URL)');
+        $cfg = self::engineConfig()[$engine];
+
+        $env = getenv($cfg['env']);
+        $url = ($env === false || $env === '') ? null : $env;
+        if ($url === null || !$this->reachable($url)) {
+            $this->markTestSkipped("live {$engine} not configured/reachable (set {$cfg['env']})");
         }
-        if (!class_exists(self::DRIVER_CLASS)) {
-            $this->markTestSkipped('tina4stack/ultipa driver not installed');
+        if (!class_exists($cfg['driver'])) {
+            $this->markTestSkipped("{$engine} driver not installed ({$cfg['driver']})");
         }
 
-        $graph = GraphDatabase::create($this->url);
-        $graph->execute('MATCH (n:`' . self::LABEL . '`) DETACH DELETE n');
+        $graph = GraphDatabase::create($url);
         $this->graph = $graph;
+        $this->cleanStatement = $cfg['clean'];
+        $graph->execute($cfg['clean']);   // start on a clean slate for this label
 
         return $graph;
     }
@@ -270,8 +347,8 @@ class GraphTest extends TestCase
     {
         $parts = parse_url($url);
         $host = $parts['host'] ?? null;
-        $port = $parts['port'] ?? 60061;
-        if ($host === null) {
+        $port = $parts['port'] ?? null;
+        if ($host === null || $port === null) {
             return false;
         }
         $socket = @fsockopen($host, (int) $port, $errno, $errstr, 2.0);

--- a/tests/fixtures/test_env_contract.json
+++ b/tests/fixtures/test_env_contract.json
@@ -65,7 +65,11 @@
     "RABBITMQ": ["URL", "HOST", "PORT"],
     "MQTT": ["URL", "AUTH_URL", "TLS_URL", "EMQX_URL", "USERNAME", "PASSWORD", "CA_FILE"],
     "SMTP": ["HOST", "PORT"],
-    "IMAP": ["HOST", "PORT"]
+    "IMAP": ["HOST", "PORT"],
+    "ULTIPA": ["URL"],
+    "NEO4J": ["URL"],
+    "MEMGRAPH": ["URL"],
+    "ARANGO": ["URL"]
   },
 
   "_fixtures_comment": [


### PR DESCRIPTION
The `GraphDatabase` layer (Feature 139, ADR-0059): URL-selected adapter, portable node/edge/traverse surface + raw query/execute pass-through, neutral GraphNode/GraphEdge/GraphResult, optional per-engine drivers.

All four engines proven against **live** servers on the lab, no mocks: Ultipa (GQL), Neo4j + Memgraph (one Bolt/Cypher adapter), ArangoDB (AQL). Ships in 3.13.111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)