### PR TITLE
skill: nested plan trees + plan-first-hard-rule

### DIFF
--- a/.claude/skills/tina4-developer-php/SKILL.md
+++ b/.claude/skills/tina4-developer-php/SKILL.md
@@ -94,6 +94,22 @@ feature plan owns the detail:
 | Checkout flow      | [checkout.md](checkout.md)              | 🟡 In Progress |
 ```
 
+**Nested plans are allowed and encouraged when a feature is itself large.** You can go
+one more level deep — a big feature earns its OWN dashboard + sub-plans:
+
+```
+plan/MASTER.md                    # top dashboard
+plan/auth.md                      # simple feature
+plan/products/MASTER.md           # sub-dashboard for a large feature
+plan/products/search.md           # sub-feature detail
+plan/products/checkout-flow.md    # sub-feature detail
+```
+
+The top `plan/MASTER.md` always stays the entry point; the depth of the tree
+matches the shape of the work. A tiny single-file demo may put the whole plan
+directly in `MASTER.md`. A multi-page app with a backend + frontend + workers:
+split by feature. A big feature inside a split project: split again.
+
 A feature plan has four parts — a Scope checklist, the Tests, a Bugs section, and a Commit log:
 
 ```markdown
@@ -792,6 +808,15 @@ The app includes a health check at `/health` that Kubernetes probes can use.
 those headings are obsolete and cause agents to ignore half the plan.
 
 Every feature starts with `plan/<feature-name>.md` (and a row in `plan/MASTER.md`). No exceptions.
+
+**Plan-first is a HARD rule, not a convention.** Coding-agent shells that host
+this skill (e.g. `tina4-simple-agent`) enforce it at the tool layer: any
+`write_file` whose path is not `plan/**.md` is REFUSED until `plan/MASTER.md`
+exists on disk. That's deliberate — no code lands before the plan exists. If an
+attempt is refused, WRITE THE PLAN FIRST, then retry the code write. The rule
+holds under every mode (quick / efficient / meticulous) and applies to sub-plans
+too (any `.md` under `plan/**` counts, so `plan/products/MASTER.md` unlocks
+code just as `plan/MASTER.md` does).
 This is how you avoid building the wrong thing and how the developer tracks progress.
 
 ### From sweeping asks to small shippable chunks


### PR DESCRIPTION
## Summary

Two additions to the Working Method section of the framework developer skill:

- **Nested plans**: `plan/<feature>/MASTER.md` + `plan/<feature>/<sub>.md`
  when a feature is itself large. Depth matches the shape of the work; the
  top `plan/MASTER.md` remains the entry point.
- **Plan-first is a HARD rule**: coding-agent shells that host this skill
  (e.g. `tina4-simple-agent`) enforce it at the tool layer — any `write_file`
  whose path is not `plan/**.md` is REFUSED until `plan/MASTER.md` exists on
  disk. Applies to every mode; sub-plans under `plan/**` count and unlock
  code just as `plan/MASTER.md` does.

Mirrored change across all four framework developer skills per the Tina4
"one framework, four languages" parity rule.

## Test plan

- [ ] Skill picks up correctly on `curl -fsSL https://tina4.com/install-skills.sh | sh` after merge → tag
- [ ] Coding agent driven against this skill writes `plan/MASTER.md` before any code
- [ ] Nested tree pattern accepted by the plan-first guard (`plan/products/MASTER.md` unlocks code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)