### PR TITLE
fix(dev-admin): serve the dev-admin bundle instead of 403ing it

### DIFF
--- a/Tina4/DevAdmin.php
+++ b/Tina4/DevAdmin.php
@@ -252,8 +252,14 @@ class DevAdmin
         // the dev toolbar into the script body and desyncs Content-Length
         // against the gzipped transport, making Chrome hang waiting for
         // bytes that never arrive (SPA boot stalls, page stays blank).
+        //
+        // Path is built with dirname(__DIR__), not __DIR__ . '/..':
+        // Response::file() rejects any path containing a '..' segment
+        // (the guard that blocks `file('downloads/' . $name)` traversal,
+        // applied before realpath()), so the caller must hand it a
+        // normalised path.
         Router::get('/__dev/js/tina4-dev-admin.min.js', function (Request $request, Response $response) {
-            $jsPath = __DIR__ . '/../src/public/js/tina4-dev-admin.min.js';
+            $jsPath = dirname(__DIR__) . '/src/public/js/tina4-dev-admin.min.js';
             if (!is_file($jsPath)) {
                 return $response->text('tina4-dev-admin.min.js not found', 404);
             }
@@ -279,7 +285,7 @@ class DevAdmin
         // loops. Also emit anti-cache headers on the shell HTML so a
         // bad shell can't get pinned.
         $bundleStem = '/__dev/js/tina4-dev-admin.min.js';
-        $bundlePath = __DIR__ . '/../src/public/js/tina4-dev-admin.min.js';
+        $bundlePath = dirname(__DIR__) . '/src/public/js/tina4-dev-admin.min.js';
         $bundleTag = is_file($bundlePath) ? (string) filemtime($bundlePath) : (string) time();
         // SPA shell — bundle now derives its WS URL from `location.host`
         // directly (tina4-dev-admin PR removing the :7200 hardcode), so

--- a/tests/DevAdminBundleServeTest.php
+++ b/tests/DevAdminBundleServeTest.php
@@ -1,0 +1,120 @@
+<?php
+
+// MessageLog and RequestInspector are defined in DevAdmin.php alongside
+// DevAdmin but PSR-4 cannot autoload them individually, so we force-include
+// the file — same as DevAdminTest.
+require_once __DIR__ . '/../Tina4/DevAdmin.php';
+
+use PHPUnit\Framework\TestCase;
+use Tina4\DevAdmin;
+use Tina4\ErrorTracker;
+use Tina4\MessageLog;
+use Tina4\Request;
+use Tina4\RequestInspector;
+use Tina4\Response;
+use Tina4\Router;
+
+/**
+ * Regression: GET /__dev/js/tina4-dev-admin.min.js must SERVE the bundle.
+ *
+ * DevAdmin built the path as `__DIR__ . '/../src/public/js/…'`.
+ * Response::file() refuses any path carrying a '..' segment — the check that
+ * closes the `file('downloads/' . $name)` traversal, so it fires before
+ * realpath() — and the framework 403'd its own asset. Measured on 3.13.103
+ * and 3.13.104: status 403, body 'Forbidden'. Every /__dev dashboard loaded
+ * the shell and then rendered blank.
+ *
+ * DevAdminBundleDedupTest already asserts the bundle exists ON DISK, and it
+ * passed throughout — which is precisely how this shipped. Nothing asserted
+ * the ROUTE could hand it to a browser. That gap is what this closes.
+ *
+ * Drives the real registered route handler against the real shipped bundle.
+ * No mocks, no fixtures.
+ */
+class DevAdminBundleServeTest extends TestCase
+{
+    private const BUNDLE_ROUTE = '/__dev/js/tina4-dev-admin.min.js';
+
+    protected function setUp(): void
+    {
+        Router::clear();
+        MessageLog::reset();
+        RequestInspector::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        ErrorTracker::reset();
+        Router::clear();
+        MessageLog::reset();
+        RequestInspector::reset();
+    }
+
+    /**
+     * Register DevAdmin and invoke the bundle route exactly as the router
+     * would, returning the response it produced.
+     */
+    private function serveBundle(): Response
+    {
+        DevAdmin::register();
+
+        $callback = null;
+
+        foreach (Router::getRoutes() as $route) {
+            if (
+                $route['method'] === 'GET'
+                && $route['pattern'] === self::BUNDLE_ROUTE
+            ) {
+                $callback = $route['callback'];
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $callback,
+            'Bundle route should be registered'
+        );
+
+        $request = Request::create('GET', self::BUNDLE_ROUTE);
+
+        return $callback($request, new Response(true));
+    }
+
+    /**
+     * The discriminator. A vulnerable build answers 403 here. Asserting
+     * merely "not 404" would pass against the bug, so pin 200 exactly.
+     */
+    public function testBundleRouteServesTheBundle(): void
+    {
+        $response = $this->serveBundle();
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Substance, not just status: a stub, an empty body or an error page
+     * would all still be 200. Mirrors DevAdminBundleDedupTest's on-disk
+     * assertions, but on the bytes that actually reach the browser.
+     */
+    public function testBundleRouteServesTheRealBundleBytes(): void
+    {
+        $response = $this->serveBundle();
+        $body = $response->getBody();
+
+        $this->assertGreaterThan(100_000, strlen($body));
+        $this->assertStringContainsString('db-table-list', $body);
+    }
+
+    /**
+     * NEGATIVE CONTROL — the 403 was a path-guard refusal, never a missing
+     * file. If the bundle really were absent the route owes a 404, and a
+     * "fix" that reintroduced Forbidden must not slip through as one.
+     */
+    public function testBundleRouteNeverAnswersForbidden(): void
+    {
+        $response = $this->serveBundle();
+
+        $this->assertNotSame(403, $response->getStatusCode());
+        $this->assertNotSame('Forbidden', $response->getBody());
+    }
+}


### PR DESCRIPTION
## Problem

`GET /__dev/js/tina4-dev-admin.min.js` returns **403 Forbidden** — the
framework refusing to serve its own dev-admin SPA bundle. The `/__dev`
dashboard loads its shell, requests the bundle, gets a 403, and renders
blank. Because the toolbar's "Dashboard ↗" overlay embeds `/__dev` in an
iframe and auto-restores from `localStorage`, the failed request recurs on
*every* debug page load once opened.

## Cause

The route builds the bundle path with a `..` segment:

```php
$jsPath = __DIR__ . '/../src/public/js/tina4-dev-admin.min.js';
```

`Response::file()` **rejects any path containing a `..` segment** — the guard
that closes the `file('downloads/' . $name)` traversal, and it deliberately
fires *before* `realpath()` (see `ResponseFileTraversalTest`). So the route
hands the guard a path it is designed to refuse, and 403s its own asset. The
fix belongs in the caller, not by relaxing the guard.

## Fix

Build the path with `dirname(__DIR__)` — semantically identical, no `..`
segment reaches the guard. Applied in both places that name the bundle (the
route, and the cache-bust `$bundlePath` a few lines down).

```php
$jsPath = dirname(__DIR__) . '/src/public/js/tina4-dev-admin.min.js';
```

## Test

Adds `DevAdminBundleServeTest`, which drives the **real registered route**
and asserts it serves the bundle (`200` + real bundle bytes), never `403`.

The gap this closes: `DevAdminBundleDedupTest` already asserted the bundle
exists *on disk* and passed throughout — nothing asserted the **route** could
hand it to a browser. That is how this shipped.

## Verified

- `DevAdminBundleServeTest` fails (403) on the current base, passes with the fix — red→green.
- `DevAdminTest` + `DevAdminBundleDedupTest` + the new test: **88 tests, 244 assertions, green** on `v3` (3.13.114).
- The only `->file()` caller in `Tina4/` is this one; sweep confirms no other instance of the pattern.

## Notes

- This is PHP-only. tina4-ruby (`File.dirname(__FILE__)`, no `..`),
  tina4-python (static file handler), and tina4-nodejs (bundle generated
  inline) each avoid the `..`-through-a-guard combination.
- Sibling to #195 (dev-toolbar CSP): both are secure-by-default hardening
  that shipped without adjusting the framework's own consumers of it.
