### PR TITLE
test(response): make the absolute-path containment test portable

### DIFF
--- a/tests/ResponseFileTraversalTest.php
+++ b/tests/ResponseFileTraversalTest.php
@@ -86,11 +86,22 @@ class ResponseFileTraversalTest extends TestCase
      * No '..' at all - containment, not the '..' check, has to catch this.
      * Containment applies ONLY when the caller declared a root, so the root
      * is what makes this 403.
+     *
+     * The target is a REAL file outside the root: a missing absolute path
+     * 404s (realpath fails) before containment runs, so it would pass on a
+     * vulnerable build too. A temp file beside the root keeps this a true
+     * discriminator on every OS.
      */
     public function testFileRefusesAbsolutePathOutsideADeclaredRoot(): void
     {
-        $response = $this->serve('/etc/passwd', $this->root);
-        $this->assertSame(403, $response->getStatusCode());
+        $outside = sys_get_temp_dir() . '/tina4-outside-' . bin2hex(random_bytes(6)) . '.txt';
+        file_put_contents($outside, "OUTSIDE\n");
+        try {
+            $response = $this->serve($outside, $this->root);
+            $this->assertSame(403, $response->getStatusCode());
+        } finally {
+            @unlink($outside);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`ResponseFileTraversalTest::testFileRefusesAbsolutePathOutsideADeclaredRoot`
fails on Windows (and any non-POSIX host). It serves a hardcoded
`/etc/passwd` to prove that an absolute path outside the declared root is
refused by containment:

```php
$response = $this->serve('/etc/passwd', $this->root);
$this->assertSame(403, $response->getStatusCode());
```

On Windows `/etc/passwd` doesn't exist, so `realpath()` fails and
`Response::file()` returns **404** before the containment check runs — the
assertion sees `404 != 403` and fails, for a reason unrelated to what the
test pins. (The Linux CI is green, so it only bites contributors running
the suite locally on Windows.)

## Cause

The test needs its target to **resolve to a real file** — that's what makes
a `403` mean "refused by containment" rather than "missing." A path that
doesn't exist on the host can't satisfy that, and `/etc/passwd` is
POSIX-only.

## Fix

Serve a **real temp file created outside the root** — the exact pattern the
sibling test `testFileServesAnAbsolutePathWhenNoRootIsDeclared` already uses
(`sys_get_temp_dir()` + `try/finally` cleanup). The file lives beside the
root, not under it, so containment still refuses it. The target resolves to
a real file on every OS, so the discriminator is preserved and the test is
now portable.

## Why the test still discriminates

- The file **exists**, so `realpath()` resolves it and a vulnerable build
  (no containment) would serve it `200` — the assertion still catches the
  bug it was written for.
- It sits **outside** the declared root (a sibling of it in the temp dir),
  so a correct build refuses it `403`.

## Verified

- `ResponseFileTraversalTest`: **7 tests, 14 assertions, green** on Windows
  (was 1 failure).
- Test-only change; no production code touched.
- The file's other `/etc/passwd` reference (`testFileRefusesDeepTraversalChain`)
  needs no change — it's a relative `..` path caught by the segment check
  before any filesystem access, so it's already portable.

## Notes

- Surfaced while verifying #201 on Windows; independent of that change (this
  fails on `v3` on its own) and mergeable in any order.
