### PR TITLE
fix(messenger): negotiate AUTH and STARTTLS from the server, not from constants

### DIFF
--- a/Tina4/Messenger.php
+++ b/Tina4/Messenger.php
@@ -276,24 +276,13 @@ class Messenger
             $this->readResponse($socket, 220);
 
             // EHLO
-            $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
+            $ehlo = $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
 
-            // STARTTLS for port 587
-            if ($this->useTls && $this->port === 587) {
-                $this->sendCommand($socket, 'STARTTLS', 220);
-
-                $crypto = stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-                if ($crypto !== true) {
-                    fclose($socket);
-                    return ['success' => false, 'message' => 'STARTTLS handshake failed', 'id' => null];
-                }
-
-                // Re-EHLO after TLS
-                $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
-            }
+            // STARTTLS where the server offers it, not where the port suggests it
+            $ehlo = $this->startTls($socket, $ehlo);
 
             // AUTH LOGIN
-            if ($this->username !== null && $this->password !== null) {
+            if ($this->hasCredentials()) {
                 $this->sendCommand($socket, 'AUTH LOGIN', 334);
                 $this->sendCommand($socket, base64_encode($this->username), 334);
                 $this->sendCommand($socket, base64_encode($this->password), 235);
@@ -406,29 +395,33 @@ class Messenger
      */
     public function testConnection(): array
     {
-        if ($this->host === null || $this->port === null) {
-            return ['success' => false, 'message' => 'SMTP host and port are required'];
+        // The same never-null guard as the other two: $host is `private string`
+        // defaulting to 'localhost' and $port an `int` defaulting to 587, so
+        // this read `if (false || false)` and a Messenger with NO host
+        // configured went ahead and probed localhost:587.
+        //
+        // On a machine with nothing listening there that failed, which looked
+        // like the intended answer. On a machine running an MTA it connected to
+        // it, and the only reason testConnection() still reported failure was
+        // the empty AUTH LOGIN being rejected -- the bug above propping up the
+        // bug here. Fixing AUTH alone turned that into a reported success for a
+        // host the caller never named.
+        //
+        // smtpConfigured is the flag shouldCapture() already uses for exactly
+        // this question, and it is set from the constructor's resolved host.
+        if (!$this->smtpConfigured) {
+            return ['success' => false, 'message' => 'SMTP host is not configured'];
         }
 
         try {
             $socket = $this->connect();
             $response = $this->readResponse($socket, 220);
 
-            $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
+            $ehlo = $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
 
-            if ($this->useTls && $this->port === 587) {
-                $this->sendCommand($socket, 'STARTTLS', 220);
+            $this->startTls($socket, $ehlo);
 
-                $crypto = stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-                if ($crypto !== true) {
-                    fclose($socket);
-                    return ['success' => false, 'message' => 'STARTTLS handshake failed'];
-                }
-
-                $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
-            }
-
-            if ($this->username !== null && $this->password !== null) {
+            if ($this->hasCredentials()) {
                 $this->sendCommand($socket, 'AUTH LOGIN', 334);
                 $this->sendCommand($socket, base64_encode($this->username), 334);
                 $this->sendCommand($socket, base64_encode($this->password), 235);
@@ -889,6 +882,104 @@ class Messenger
      * @return resource
      * @throws \RuntimeException On connection failure
      */
+    /**
+     * Does the server advertise this ESMTP capability?
+     *
+     * Reads the EHLO response, whose lines look like "250-STARTTLS" for every
+     * line but the last and "250 STARTTLS" for that one. The word boundary
+     * matters: "AUTH" must not match "AUTH=PLAIN LOGIN" as a different
+     * capability, and a bare prefix match would say a server offering
+     * "STARTTLSX" supports STARTTLS.
+     */
+    private function serverSupports(string $ehloResponse, string $capability): bool
+    {
+        foreach (preg_split('/\R/', $ehloResponse) ?: [] as $line) {
+            if (preg_match('/^250[ -]' . preg_quote($capability, '/') . '\b/i', trim($line))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Upgrade the connection with STARTTLS, and return the EHLO response that
+     * is valid from here on.
+     *
+     * The capability list is re-read after a successful upgrade because a
+     * server may advertise different capabilities once the channel is
+     * encrypted -- AUTH in particular is commonly withheld until then.
+     *
+     * This USED TO BE gated on `$this->port === 587`. A caller who asked for
+     * encryption on any other port silently got none: the connection was made
+     * in clear, the credentials went out in clear, and send() still returned
+     * success. Submission on 25 and 2525 is ordinary, so that was not a corner
+     * case, and nothing in the result told the caller their mail had been sent
+     * unencrypted. Whether the channel can be encrypted is a property of the
+     * server, not of the port number, so ask the server.
+     *
+     * The two encryption modes are deliberately not equivalent:
+     *   'starttls'  the caller demanded encryption -- fail loudly if it is not
+     *               on offer, rather than quietly downgrading them
+     *   'tls'       the default, and opportunistic -- upgrade where possible,
+     *               warn where not. Failing here would break every app already
+     *               pointed at a plain local MTA, which is the setup this
+     *               change is meant to enable.
+     * 'ssl' and 'none' never reach this: 465 is already wrapped by connect().
+     */
+    private function startTls($socket, string $ehloResponse): string
+    {
+        if (!$this->useTls) {
+            return $ehloResponse;
+        }
+
+        if (!$this->serverSupports($ehloResponse, 'STARTTLS')) {
+            if ($this->encryption === 'starttls') {
+                fclose($socket);
+                throw new \RuntimeException(
+                    "STARTTLS was requested but {$this->host}:{$this->port} does not offer it"
+                );
+            }
+
+            Debug::message(
+                "SMTP server {$this->host}:{$this->port} does not offer STARTTLS, continuing unencrypted",
+                Debug::LEVEL_WARNING
+            );
+
+            return $ehloResponse;
+        }
+
+        $this->sendCommand($socket, 'STARTTLS', 220);
+
+        if (stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT) !== true) {
+            fclose($socket);
+            throw new \RuntimeException('STARTTLS handshake failed');
+        }
+
+        return $this->sendCommand($socket, 'EHLO ' . gethostname(), 250);
+    }
+
+    /**
+     * Are there credentials to authenticate with?
+     *
+     * The guard here was `$this->username !== null && $this->password !== null`
+     * on properties typed `private string` that default to ''. Neither is ever
+     * null, so the branch ALWAYS ran: a Messenger with no credentials
+     * configured still sent AUTH LOGIN with two empty base64 strings, and the
+     * server rejected the handshake before the message was ever offered.
+     *
+     * The practical consequence was that Messenger could not talk to a local
+     * MTA at all -- the case where you want no credentials, because the relay
+     * trusts loopback and does the queueing and retrying for you.
+     *
+     * The username alone decides, matching Messaging\Messenger, which has
+     * always used `!empty($this->settings->smtpUsername)`.
+     */
+    private function hasCredentials(): bool
+    {
+        return $this->username !== '';
+    }
+
     private function connect()
     {
         $address = $this->host . ':' . $this->port;

--- a/tests/MessengerSmtpNegotiationTest.php
+++ b/tests/MessengerSmtpNegotiationTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use TestServer;
+use Tina4\Messenger;
+
+/**
+ * What Messenger puts on the wire BEFORE it offers the message.
+ *
+ * Two decisions were wrong, and neither was visible in send()'s return value,
+ * which is why they survived. Both were found against a live Postfix on
+ * 26 August 2026 while moving an application off a flaky third-party relay and
+ * onto a local queueing MTA — the thing you would reach for precisely because
+ * it retries, and the thing Messenger could not talk to.
+ *
+ *   1. AUTH LOGIN was sent unconditionally. The guard read
+ *      `$this->username !== null && $this->password !== null` against two
+ *      properties typed `private string` that default to ''. Neither is ever
+ *      null, so a Messenger with no credentials at all still sent AUTH LOGIN
+ *      with two empty base64 strings. Against a relay that trusts loopback and
+ *      wants no credentials, the far end rejected the handshake and the mail
+ *      never left. The observed symptom was a bare
+ *      "454 4.7.0 Temporary authentication failure", which reads like a
+ *      credential problem and sends you looking in the wrong place.
+ *
+ *   2. STARTTLS was gated on `$this->port === 587`. A caller asking for
+ *      encryption on any other port silently got none — credentials in clear,
+ *      and send() still returned success. Submission on 25 and 2525 is
+ *      ordinary, so this was not a corner case.
+ *
+ * NO MOCKS. Each test starts a real listener (fixtures/smtp_negotiation_server
+ * .php), Messenger speaks real SMTP to it over a real socket, and the
+ * assertions are made against the transcript the server recorded. Nothing here
+ * inspects Messenger's private state or stubs a socket: a test that asserted
+ * "the guard is now `!== ''`" would pass just as happily if the guard were
+ * never reached.
+ *
+ * Every behaviour is pinned from BOTH sides — the command is sent when it
+ * should be AND absent when it should not. A test that only checks the absence
+ * of AUTH LOGIN passes on a Messenger that has stopped talking altogether.
+ */
+class MessengerSmtpNegotiationTest extends TestCase
+{
+    private ?TestServer $server = null;
+    private string $transcript = '';
+
+    protected function setUp(): void
+    {
+        $this->transcript = tempnam(sys_get_temp_dir(), 'tina4-smtp-transcript-');
+
+        // A configured host means send(), not DevMailbox capture. These have to
+        // be off explicitly: inherited from the developer's own environment
+        // they would divert the message into a folder and every assertion below
+        // would be made against a transcript nothing ever wrote to.
+        putenv('TINA4_MAIL_CAPTURE=0');
+        putenv('TINA4_MAIL_REDIRECT_TO');
+        putenv('TINA4_MAIL_HOST');
+        putenv('TINA4_MAIL_USERNAME');
+        putenv('TINA4_MAIL_PASSWORD');
+        putenv('TINA4_MAIL_ENCRYPTION');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->server?->stop();
+        $this->server = null;
+
+        if ($this->transcript !== '' && is_file($this->transcript)) {
+            unlink($this->transcript);
+        }
+
+        putenv('TINA4_MAIL_CAPTURE');
+    }
+
+    /**
+     * Start the recording SMTP server advertising exactly $capabilities, and
+     * return the port it is on.
+     */
+    private function startServer(string $capabilities): int
+    {
+        $this->server = TestServer::startScript(
+            __DIR__ . '/fixtures/smtp_negotiation_server.php',
+            [$this->transcript, $capabilities]
+        );
+
+        $port = parse_url($this->server->base(), PHP_URL_PORT);
+        self::assertIsInt($port, 'the test server did not report a port');
+
+        // The port is whatever the OS handed out. If it ever WERE 587 the
+        // STARTTLS tests would pass for the old reason rather than the new one,
+        // and would stop testing anything.
+        self::assertNotSame(587, $port, 'ephemeral port collided with submission');
+
+        return $port;
+    }
+
+    /** What the client actually put on the wire. */
+    private function transcript(): string
+    {
+        return is_file($this->transcript) ? (string)file_get_contents($this->transcript) : '';
+    }
+
+    private function messenger(int $port, string $username = '', string $encryption = 'none'): Messenger
+    {
+        return new Messenger(
+            host: '127.0.0.1',
+            port: $port,
+            username: $username,
+            password: $username === '' ? '' : 'irrelevant-to-this-test',
+            fromAddress: 'sender@tina4.test',
+            fromName: 'Tina4 Test',
+            encryption: $encryption,
+        );
+    }
+
+    private function send(Messenger $messenger): array
+    {
+        return $messenger->send(
+            to: 'recipient@tina4.test',
+            subject: 'negotiation',
+            body: 'body',
+        );
+    }
+
+    // ---------------------------------------------------------------- AUTH
+
+    public function testNoCredentialsMeansNoAuthCommand(): void
+    {
+        $port = $this->startServer('AUTH');
+
+        $result = $this->send($this->messenger($port));
+
+        self::assertTrue(
+            $result['success'],
+            'send failed with no credentials against a server that wants none: ' . $result['message']
+        );
+
+        $transcript = $this->transcript();
+        self::assertStringNotContainsString('AUTH LOGIN', $transcript);
+        self::assertStringContainsString('MAIL FROM', $transcript, 'the message was never offered');
+        self::assertStringContainsString('DATA-END', $transcript, 'the body was never delivered');
+    }
+
+    public function testCredentialsAreStillSent(): void
+    {
+        $port = $this->startServer('AUTH');
+
+        $result = $this->send($this->messenger($port, 'someone@tina4.test'));
+
+        self::assertTrue($result['success'], $result['message']);
+
+        $transcript = $this->transcript();
+        self::assertStringContainsString('AUTH LOGIN', $transcript);
+        self::assertStringContainsString(
+            'AUTH-USERNAME ' . base64_encode('someone@tina4.test'),
+            $transcript,
+            'the username on the wire is not the one that was configured'
+        );
+    }
+
+    // ------------------------------------------------------------- STARTTLS
+
+    public function testStartTlsIsIssuedOnAPortThatIsNot587(): void
+    {
+        $port = $this->startServer('STARTTLS,AUTH');
+
+        $result = $this->send($this->messenger($port, '', 'tls'));
+
+        self::assertStringContainsString(
+            'STARTTLS',
+            $this->transcript(),
+            'encryption was asked for and the server offered it, but the client never asked to upgrade'
+        );
+
+        // The fixture answers 220 and then drops rather than completing a real
+        // handshake, so the send cannot succeed. That is honest: the client is
+        // told the channel could not be secured instead of quietly sending in
+        // clear, which is the whole point of the change.
+        self::assertFalse($result['success']);
+        self::assertStringContainsString('STARTTLS', $result['message']);
+    }
+
+    public function testStartTlsIsSkippedWhenTheServerDoesNotOfferIt(): void
+    {
+        $port = $this->startServer('AUTH');
+
+        $result = $this->send($this->messenger($port, '', 'tls'));
+
+        // 'tls' is opportunistic: upgrade where possible, deliver where not.
+        // Failing here would break every application already pointed at a plain
+        // local MTA, which is the setup this change exists to enable.
+        self::assertTrue($result['success'], $result['message']);
+        self::assertStringNotContainsString('STARTTLS', $this->transcript());
+    }
+
+    public function testExplicitStarttlsFailsLoudlyWhenNotOffered(): void
+    {
+        $port = $this->startServer('AUTH');
+
+        $result = $this->send($this->messenger($port, '', 'starttls'));
+
+        // A caller who named starttls asked for encryption specifically. Sending
+        // their message in clear because the server was not configured for it
+        // would be the silent downgrade this change removes.
+        self::assertFalse($result['success'], 'mail was sent unencrypted after starttls was demanded');
+        self::assertStringContainsString('STARTTLS', $result['message']);
+        self::assertStringNotContainsString('MAIL FROM', $this->transcript());
+    }
+}

--- a/tests/fixtures/smtp_negotiation_server.php
+++ b/tests/fixtures/smtp_negotiation_server.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * A REAL SMTP listener that records the client's side of the conversation.
+ *
+ * NO MOCKS: Messenger opens a real TCP socket to this and speaks real SMTP.
+ * The transcript this writes is the evidence — what the client actually put on
+ * the wire, not what a double was told to report.
+ *
+ * It exists because the two things MessengerSmtpNegotiationTest proves are
+ * decisions the client makes BEFORE the message is offered: whether to send
+ * AUTH LOGIN, and whether to send STARTTLS. Neither shows up in send()'s
+ * return value — the old code sent AUTH LOGIN with two empty strings and the
+ * only symptom was a 5xx from the far end. You have to look at the wire.
+ *
+ * The advertised capabilities are chosen per test, because that is the input
+ * that should drive the client's behaviour now that the port number no longer
+ * does.
+ *
+ * STARTTLS is answered 220 and then the connection is dropped rather than
+ * genuinely upgraded. Generating a certificate here would prove PHP can do a
+ * TLS handshake, which was never in doubt; the question is whether the client
+ * ISSUES the command, and by the time we answer it that is already recorded.
+ *
+ * Usage:
+ *   php smtp_negotiation_server.php <port> <transcript-file> [CAP,CAP,...]
+ *
+ * Capabilities default to "AUTH". Pass "STARTTLS,AUTH" to offer both, or
+ * "NONE" to advertise nothing beyond the bare minimum.
+ */
+
+declare(strict_types=1);
+
+$port       = (int)($argv[1] ?? 0);
+$transcript = (string)($argv[2] ?? '');
+$capsArg    = (string)($argv[3] ?? 'AUTH');
+
+if ($port <= 0 || $transcript === '') {
+    fwrite(STDERR, "usage: smtp_negotiation_server.php <port> <transcript-file> [CAPS]\n");
+    exit(2);
+}
+
+$caps = $capsArg === 'NONE' ? [] : array_filter(array_map('trim', explode(',', $capsArg)));
+
+$server = @stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
+if ($server === false) {
+    fwrite(STDERR, "could not listen on {$port}: {$errstr} ({$errno})\n");
+    exit(1);
+}
+
+/** Append one line of evidence. Opened per write so a failing test can read it mid-run. */
+$record = static function (string $line) use ($transcript): void {
+    file_put_contents($transcript, rtrim($line, "\r\n") . "\n", FILE_APPEND | LOCK_EX);
+};
+
+$reply = static function ($conn, string $line): void {
+    fwrite($conn, $line . "\r\n");
+};
+
+while (true) {
+    $conn = @stream_socket_accept($server, -1);
+    if ($conn === false) {
+        continue;
+    }
+
+    // TestServer's readiness probe connects and closes without reading. That
+    // arrives here as an immediate EOF, which is not a client and must not be
+    // recorded as one.
+    $reply($conn, '220 tina4-test ESMTP');
+
+    $inData = false;
+
+    while (($line = fgets($conn, 4096)) !== false) {
+        $line = rtrim($line, "\r\n");
+
+        if ($inData) {
+            if ($line === '.') {
+                $inData = false;
+                $record('DATA-END');
+                $reply($conn, '250 2.0.0 Ok: queued');
+            }
+            // Message body is deliberately not recorded; this test is about
+            // the negotiation, and a transcript holding the whole message
+            // would make the assertions harder to read, not easier.
+            continue;
+        }
+
+        $record($line);
+        $verb = strtoupper(strtok($line, ' ') ?: '');
+
+        switch ($verb) {
+            case 'EHLO':
+                // Last line uses a space, every earlier line a hyphen. Messenger
+                // parses this to decide what the server supports, so the shape
+                // has to be right.
+                $lines = array_merge(['tina4-test greets you'], $caps);
+                $last  = count($lines) - 1;
+                foreach ($lines as $i => $cap) {
+                    $reply($conn, '250' . ($i === $last ? ' ' : '-') . $cap);
+                }
+                break;
+
+            case 'HELO':
+                $reply($conn, '250 tina4-test');
+                break;
+
+            case 'STARTTLS':
+                $reply($conn, '220 2.0.0 Ready to start TLS');
+                // See the header: the command was the point, and it is recorded.
+                break 2;
+
+            case 'AUTH':
+                $reply($conn, '334 VXNlcm5hbWU6');
+                $user = rtrim((string)fgets($conn, 4096), "\r\n");
+                $record('AUTH-USERNAME ' . $user);
+                $reply($conn, '334 UGFzc3dvcmQ6');
+                $pass = rtrim((string)fgets($conn, 4096), "\r\n");
+                $record('AUTH-PASSWORD-LENGTH ' . strlen($pass));
+                $reply($conn, '235 2.7.0 Authentication successful');
+                break;
+
+            case 'MAIL':
+            case 'RCPT':
+            case 'RSET':
+            case 'NOOP':
+                $reply($conn, '250 2.1.0 Ok');
+                break;
+
+            case 'DATA':
+                $inData = true;
+                $reply($conn, '354 End data with <CR><LF>.<CR><LF>');
+                break;
+
+            case 'QUIT':
+                $reply($conn, '221 2.0.0 Bye');
+                break 2;
+
+            default:
+                $reply($conn, '500 5.5.2 Command unrecognized');
+                break;
+        }
+    }
+
+    fclose($conn);
+}


### PR DESCRIPTION
Found while moving an application off a third-party relay that was dropping connections, onto a local Postfix that queues and retries. Messenger could not talk to the local MTA at all.

Three guards test `!== null` against properties that can never be null.

1. `Tina4\Messenger` line 296 and 431: `if ($this->username !== null && $this->password !== null)` against `private string` properties that default to `''`. Never null, so AUTH LOGIN was always sent. A Messenger with no credentials configured sent two empty base64 strings and the far end rejected the handshake. The symptom is `454 4.7.0 Temporary authentication failure`, which reads like a credential problem.

2. `if ($this->useTls && $this->port === 587)` gated STARTTLS on the port number. Encryption asked for on any other port was silently not applied. The connection was made in clear, the credentials went out in clear, and `send()` still returned success. Submission on 25 and 2525 is ordinary.

3. `testConnection()` had the same shape in its own guard: `$this->host === null` against a string defaulting to `localhost`, so a Messenger with no host configured probed localhost:587. It only reported failure because the empty AUTH was rejected, so fixing 1 alone turned it into a false success. It now uses the `smtpConfigured` flag that `shouldCapture()` already uses.

Whether a channel can be encrypted is a property of the server, not of the port, so the EHLO response is now read and the capability drives the decision. The two modes are deliberately not equivalent. `starttls` means the caller asked for encryption specifically and fails loudly when it is not offered. `tls` stays opportunistic so applications already pointed at a plain MTA keep working. Behaviour on 587 is unchanged.

Tests: `tests/MessengerSmtpNegotiationTest.php` plus a recording SMTP listener in `tests/fixtures/`. No mocks. Messenger speaks real SMTP over a real socket and the assertions are made against the transcript the server recorded. Each behaviour is pinned from both sides, present when it should be and absent when it should not, because a test that only checks AUTH LOGIN is absent would pass on a Messenger that stopped talking.

Verified on PHP 8.2.33:

- 5 new tests pass. 3 of them fail against the current code, which is the point.
- All 106 existing Messenger tests pass.
- Full suite run twice, patched and pristine, failure lists diffed: 44 against 48, no regressions. The difference is the 3 new tests plus one unrelated flaky one. The 44 that remain are pre-existing and are MySQL access failures in my environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R8pbNkKAXvjjwVJtJwJ2A
