### PR TITLE
fix(server): dual-stack loopback so localhost is reachable on Windows

### DIFF
--- a/Tina4/Server.php
+++ b/Tina4/Server.php
@@ -136,6 +136,17 @@ class Server
     private $socket = null;
 
     /**
+     * @var array<int, resource> Extra listeners on the MAIN port for the
+     * sibling loopback family, keyed by resource id.
+     *
+     * `localhost` resolves to ::1 (IPv6) first on Windows, so a server bound
+     * only to 127.0.0.1 refused the browser even though it was serving.
+     * Binding both loopback families closes that gap. These are accepted
+     * exactly like $socket and are closed alongside it.
+     */
+    private array $extraListenSockets = [];
+
+    /**
      * Serve each request in a forked child, so a blocking handler cannot freeze
      * the server. Resolved once at start(); false where pcntl is unavailable.
      */
@@ -372,40 +383,7 @@ class Server
             exit(1);
         }
 
-        $context = stream_context_create([
-            'socket' => [
-                'backlog' => 1024,
-                'so_reuseport' => true,
-                'tcp_nodelay' => true,
-            ],
-        ]);
-        $this->socket = @stream_socket_server(
-            "tcp://{$this->host}:{$this->port}",
-            $errno,
-            $errstr,
-            STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
-            $context
-        );
-
-        if (!$this->socket) {
-            // Port is in use — kill the occupying process and try once more
-            $this->freePort($this->port);
-            $this->socket = @stream_socket_server(
-                "tcp://{$this->host}:{$this->port}",
-                $errno,
-                $errstr,
-                STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
-                $context
-            );
-        }
-
-        if (!$this->socket) {
-            throw new \RuntimeException(
-                "Could not free port {$this->port}: {$errstr} ({$errno})"
-            );
-        }
-
-        stream_set_blocking($this->socket, false);
+        $this->openListenSockets();
         $this->running = true;
         self::$instance = $this;
         // Record THIS process as the Tina4 dev server on the main port, so a
@@ -541,6 +519,125 @@ class Server
     }
 
     /**
+     * Open the main listening socket, plus a sibling loopback listener so
+     * `localhost` is reachable on both IPv4 and IPv6.
+     *
+     * The primary bind keeps its port-takeover retry and its fail-closed
+     * throw (which the CLI catches to fall back to `php -S`). The sibling
+     * binds are best-effort — see openLoopbackSiblings().
+     *
+     * @throws \RuntimeException when the main port cannot be bound.
+     */
+    private function openListenSockets(): void
+    {
+        $context = stream_context_create([
+            'socket' => [
+                'backlog' => 1024,
+                'so_reuseport' => true,
+                'tcp_nodelay' => true,
+            ],
+        ]);
+
+        $this->socket = @stream_socket_server(
+            "tcp://{$this->host}:{$this->port}",
+            $errno,
+            $errstr,
+            STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+            $context
+        );
+
+        if (!$this->socket) {
+            // Port is in use — kill the occupying process and try once more.
+            $this->freePort($this->port);
+            $this->socket = @stream_socket_server(
+                "tcp://{$this->host}:{$this->port}",
+                $errno,
+                $errstr,
+                STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+                $context
+            );
+        }
+
+        if (!$this->socket) {
+            throw new \RuntimeException(
+                "Could not free port {$this->port}: {$errstr} ({$errno})"
+            );
+        }
+
+        stream_set_blocking($this->socket, false);
+
+        $this->openLoopbackSiblings();
+    }
+
+    /**
+     * Also listen on the sibling loopback family, best-effort.
+     *
+     * Only fires for a loopback or wildcard host — an explicit LAN address
+     * is bound exactly as asked. The sibling context deliberately omits
+     * so_reuseport: a family the primary socket already answers then fails
+     * to re-bind and is skipped, instead of stacking a duplicate listener
+     * on the same address (which SO_REUSEPORT would otherwise allow).
+     */
+    private function openLoopbackSiblings(): void
+    {
+        $siblings = self::loopbackBindHosts($this->host);
+
+        if ($siblings === []) {
+            return;
+        }
+
+        $context = stream_context_create([
+            'socket' => [
+                'backlog' => 1024,
+                'tcp_nodelay' => true,
+            ],
+        ]);
+
+        foreach ($siblings as $host) {
+            $sibling = @stream_socket_server(
+                "tcp://{$host}:{$this->port}",
+                $errno,
+                $errstr,
+                STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+                $context
+            );
+
+            if (!$sibling) {
+                // Already answered by the primary bind, or the family is
+                // unavailable — either way there is nothing to add.
+                continue;
+            }
+
+            stream_set_blocking($sibling, false);
+            $this->extraListenSockets[(int)$sibling] = $sibling;
+        }
+    }
+
+    /**
+     * Sibling loopback addresses to ALSO listen on, so `localhost` reaches
+     * this server whether it resolves to IPv4 (127.0.0.1) or IPv6 (::1).
+     *
+     * Returns only the families a direct bind of $host does not already
+     * cover. A host that is neither loopback nor a wildcard yields an empty
+     * list — an explicit address is left exactly as asked.
+     *
+     * @param string $host The host the main socket binds.
+     *
+     * @return string[] Extra bind addresses (possibly empty).
+     */
+    public static function loopbackBindHosts(string $host): array
+    {
+        $normalized = strtolower(trim($host, " \t[]"));
+
+        return match ($normalized) {
+            'localhost' => ['127.0.0.1', '[::1]'],
+            '127.0.0.1', '0.0.0.0' => ['[::1]'],
+            '::1', '::' => ['127.0.0.1'],
+            default => [],
+        };
+    }
+
+    /**
      * Accept and serve until stopped.
      *
      * Extracted from start() so a pool worker can run the same loop the
@@ -588,7 +685,12 @@ class Server
                     $this->endRequestChild();
                 }
 
-                $read = array_merge([$this->socket], $this->clients);
+                $read = array_merge(
+                    [$this->socket],
+                    $this->extraListenSockets,
+                    $this->clients
+                );
+
                 if ($this->aiSocket !== null) {
                     $read[] = $this->aiSocket;
                 }
@@ -636,9 +738,13 @@ class Server
                     if (!is_resource($socket)) {
                         continue;
                     }
-                    if ($socket === $this->socket) {
-                        // Accept new connection
-                        $client = @stream_socket_accept($this->socket, 0, $peerName);
+
+                    if (
+                        $socket === $this->socket
+                        || isset($this->extraListenSockets[(int)$socket])
+                    ) {
+                        // Accept new connection (main port, any loopback family)
+                        $client = @stream_socket_accept($socket, 0, $peerName);
                         if ($client) {
                             stream_set_blocking($client, false);
                             $resourceId = (int)$client;
@@ -743,6 +849,15 @@ class Server
             @fclose($this->socket);
             $this->socket = null;
         }
+
+        foreach ($this->extraListenSockets as $id => $sibling) {
+            if (is_resource($sibling)) {
+                @fclose($sibling);
+            }
+
+            unset($this->extraListenSockets[$id]);
+        }
+
         if ($this->aiSocket !== null) {
             @fclose($this->aiSocket);
             $this->aiSocket = null;

--- a/tests/ServerDualStackLoopbackTest.php
+++ b/tests/ServerDualStackLoopbackTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The dev server must be reachable on BOTH loopback families.
+ *
+ * Written before the dual-stack fix lands — it is the gate for it. Windows
+ * resolves `localhost` to ::1 (IPv6) first, so a server bound only to
+ * 127.0.0.1 refused the browser with ERR_CONNECTION_REFUSED even though it
+ * was serving. Binding both loopback families closes that gap.
+ *
+ * These are real sockets: the server binds through its own
+ * openListenSockets(), and a real TCP client connects on each family. No
+ * subprocess is spawned, so it runs on Windows too (where the bug lives) as
+ * well as on Linux CI.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tina4\Server;
+
+class ServerDualStackLoopbackTest extends TestCase
+{
+    /**
+     * loopbackBindHosts() names the sibling family a direct bind of the host
+     * would miss, and leaves an explicit LAN address untouched.
+     */
+    public function testLoopbackBindHostsNamesTheSiblingFamily(): void
+    {
+        $this->assertSame(
+            ['[::1]'],
+            Server::loopbackBindHosts('127.0.0.1'),
+            'an IPv4-loopback host needs the IPv6 sibling'
+        );
+        $this->assertSame(
+            ['[::1]'],
+            Server::loopbackBindHosts('0.0.0.0'),
+            'the IPv4 wildcard still misses IPv6 loopback'
+        );
+        $this->assertSame(
+            ['127.0.0.1'],
+            Server::loopbackBindHosts('::1'),
+            'an IPv6-loopback host needs the IPv4 sibling'
+        );
+        $this->assertSame(
+            ['127.0.0.1', '[::1]'],
+            Server::loopbackBindHosts('localhost'),
+            'localhost resolves per-OS, so bind both explicitly'
+        );
+        $this->assertSame(
+            [],
+            Server::loopbackBindHosts('192.168.1.10'),
+            'an explicit LAN address is bound exactly as asked'
+        );
+    }
+
+    /**
+     * A server bound to IPv4 loopback also answers on IPv6 loopback — the
+     * dual-stack behaviour a Windows `localhost` browser depends on.
+     */
+    public function testServerBoundToIpv4LoopbackAlsoAnswersOnIpv6(): void
+    {
+        if (!self::ipv6LoopbackAvailable()) {
+            $this->markTestSkipped('IPv6 loopback (::1) is unavailable here');
+        }
+
+        $port = \FreePort::get();
+        $server = new Server('127.0.0.1', $port);
+
+        $this->openListeners($server);
+
+        try {
+            $this->assertTrue(
+                self::accepts('127.0.0.1', $port),
+                'the primary IPv4 loopback listener must accept'
+            );
+            $this->assertTrue(
+                self::accepts('[::1]', $port),
+                'IPv6 loopback must ALSO accept after the dual-stack fix'
+            );
+        } finally {
+            $this->closeListeners($server);
+        }
+    }
+
+    /** Bind the server's listeners without entering the accept loop. */
+    private function openListeners(Server $server): void
+    {
+        (new \ReflectionMethod(Server::class, 'openListenSockets'))
+            ->invoke($server);
+    }
+
+    /** Release the bound listeners. */
+    private function closeListeners(Server $server): void
+    {
+        (new \ReflectionMethod(Server::class, 'closeListeners'))
+            ->invoke($server);
+    }
+
+    /** True when a TCP client can connect to $host:$port. */
+    private static function accepts(string $host, int $port): bool
+    {
+        $client = @stream_socket_client("tcp://{$host}:{$port}", $e1, $e2, 1);
+        if ($client === false) {
+            return false;
+        }
+        fclose($client);
+
+        return true;
+    }
+
+    /** True when this host can bind IPv6 loopback at all. */
+    private static function ipv6LoopbackAvailable(): bool
+    {
+        $probe = @stream_socket_server('tcp://[::1]:0', $e1, $e2);
+        if ($probe === false) {
+            return false;
+        }
+        fclose($probe);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Problem

On native Windows, `tina4 serve` / `Server::start()` prints "Server ready"
but the browser gets `ERR_CONNECTION_REFUSED` at `http://localhost:<port>`,
even though the server is running and healthy.

## Root cause

The dev server binds a single address family. Windows resolves `localhost`
to `::1` (IPv6) **before** `127.0.0.1` (IPv4), so a server bound only to
`127.0.0.1` is unreachable via `localhost` — the client knocks on the IPv6
door while the server is listening on the IPv4 one. The socket layer itself
works fine on Windows; the gap is purely which loopback family is bound.

This is not a `pcntl`/fork issue — the serial accept loop is fully
functional on Windows. A server bound to one loopback family genuinely
serves real HTTP on it; it simply never bound the other.

## Fix

Bind **both** loopback families when serving locally, so `localhost`
connects regardless of how it resolves:

- New `Server::loopbackBindHosts()` returns the sibling family a direct
  bind of the host would miss (`127.0.0.1`/`0.0.0.0` → `[::1]`;
  `::1`/`::` → `127.0.0.1`; `localhost` → both). A non-loopback,
  non-wildcard host returns `[]` and is bound exactly as asked.
- Binding is extracted into `openListenSockets()`, which keeps the
  existing port-takeover retry and the fail-closed `RuntimeException`
  (which the CLI already catches to fall back to `php -S`), then binds
  the sibling loopback via `openLoopbackSiblings()`.
- Sibling binds are best-effort and use a context without `so_reuseport`,
  so a family already answered by the primary socket cleanly fails to
  re-bind and is skipped rather than stacking a duplicate listener.
- Extra listeners join the `stream_select` read-set, are accepted exactly
  like the primary socket, and are closed alongside it in `closeListeners()`.

No behaviour change for an explicit LAN address — only loopback and
wildcard hosts gain the sibling listener.

## Tests

`tests/ServerDualStackLoopbackTest.php` (new, behavioural, real sockets,
no subprocess so it runs on Windows too):

- `loopbackBindHosts()` returns the correct sibling family per host.
- A server bound to IPv4 loopback also accepts on IPv6 loopback.

Written test-first: with the sibling binding removed it fails on
`[::1]` ("Failed asserting that false is true"); with the fix it passes.

## Verification

- Windows 11 / PHP 8.4: a live server bound to `127.0.0.1` returns
  `HTTP/1.1 200 OK` on **both** `127.0.0.1` and `[::1]`.
- Linux / PHP 8.4 (Docker): the server test subset — dual-stack, parity,
  concurrency, request-limits, worker-pool, protocol-gaps — passes.

## Out of scope

The separate native `tina4` CLI behaviour of returning to the prompt on
Windows lives in the Rust CLI, not here, and is not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
