### PR TITLE
fix(dev-admin): a version check that did not happen says so

### DIFF
--- a/Tina4/DevAdmin.php
+++ b/Tina4/DevAdmin.php
@@ -406,25 +406,43 @@ class DevAdmin
             return $response->json(['ok' => true, 'type' => $type]);
         });
 
-        // API: Version check — proxy to avoid CORS issues with registry APIs
+        // API: Version check — proxy to avoid CORS issues with registry APIs.
+        //
+        // A check that did not happen says so. This used to fall back to
+        // latest = current on any failure, and the toolbar renders that as a
+        // green "You are up to date!" — so a developer several releases behind,
+        // on a machine with no route out, was told the opposite of the truth.
+        // The toolbar already had the right message for this case and could
+        // never reach it, because the failure arrived as a success.
         Router::get('/__dev/api/version-check', function (Request $request, Response $response) {
             $current = App::$VERSION;
-            $latest = $current;
+            $failed = fn(string $why) => $response->json([
+                'current' => $current,
+                'latest' => null,
+                'error' => $why,
+            ]);
             try {
                 $ctx = stream_context_create(['http' => ['timeout' => 5, 'ignore_errors' => true]]);
                 $json = @file_get_contents('https://repo.packagist.org/p2/tina4stack/tina4php.json', false, $ctx);
-                if ($json) {
-                    $data = json_decode($json, true);
-                    $packages = $data['packages']['tina4stack/tina4php'] ?? [];
-                    $versions = array_column($packages, 'version');
-                    // Filter: stable only (no dev, no rc, no x)
-                    $stable = array_filter($versions, fn($v) => preg_match('/^v?\d+\.\d+\.\d+$/', $v));
-                    $stable = array_map(fn($v) => ltrim($v, 'v'), $stable);
-                    usort($stable, 'version_compare');
-                    $latest = end($stable) ?: $current;
+                if ($json === false || $json === '') {
+                    return $failed('could not reach Packagist');
                 }
-            } catch (\Throwable) {
-                // Offline or timeout — return current as latest
+                $data = json_decode($json, true);
+                $packages = $data['packages']['tina4stack/tina4php'] ?? [];
+                $versions = array_column($packages, 'version');
+                // Filter: stable only (no dev, no rc, no x)
+                $stable = array_filter($versions, fn($v) => preg_match('/^v?\d+\.\d+\.\d+$/', $v));
+                $stable = array_map(fn($v) => ltrim($v, 'v'), $stable);
+                usort($stable, 'version_compare');
+                $latest = end($stable);
+                // Reaching Packagist is not the same as learning the version:
+                // an answer we cannot read one out of is the same lie by
+                // another route.
+                if ($latest === false || $latest === null || $latest === '') {
+                    return $failed('Packagist did not report a stable version');
+                }
+            } catch (\Throwable $e) {
+                return $failed($e->getMessage());
             }
             return $response->json(['current' => $current, 'latest' => $latest]);
         });
@@ -3149,6 +3167,13 @@ CSS;
         el.className = 't4-ok';
         el.innerHTML = 'Latest: <strong class="t4-ok">v' + latest + '</strong> &mdash; You are up to date!';
     }
+    // A check that did not happen is not a clean bill of health. The server
+    // sends latest: null when it could not reach the registry, and saying so is
+    // the whole point -- "up to date" here would be a guess dressed as a fact.
+    function couldNotCheck(el, why) {
+        el.className = 't4-err';
+        el.textContent = 'Could not check for updates' + (why ? ' (' + why + ')' : '');
+    }
     function checkVersion() {
         if (modal.style.display === 'block') { modal.style.display = 'none'; return; }
         modal.style.display = 'block';
@@ -3157,6 +3182,7 @@ CSS;
         el.textContent = 'Checking for updates...';
         fetch('/__dev/api/version-check').then(function (r) { return r.json(); }).then(function (d) {
             var latest = d.latest, current = d.current;
+            if (!latest) { couldNotCheck(el, d.error); return; }
             if (latest === current) { upToDate(el, latest); return; }
             var cP = current.split('.').map(Number), lP = latest.split('.').map(Number);
             var isNewer = false, i, c, l;

--- a/tests/DevAdminVersionCheckTest.php
+++ b/tests/DevAdminVersionCheckTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Tina4 — The Intelligent Native Application 4ramework
+ * Copyright 2007 - current Tina4
+ * License: MIT https://opensource.org/licenses/MIT
+ *
+ * The dev-admin version check must not report "up to date" for a check it
+ * never made.
+ *
+ * It used to answer HTTP 200 with latest == current whenever the call to
+ * Packagist failed, and the toolbar renders that as a green
+ * "Latest: vX — You are up to date!". A developer several releases behind, on
+ * a machine with no route out, was told the opposite of the truth — and the
+ * toolbar's own "Could not check for updates" branch could never fire, because
+ * the failure arrived as a success.
+ *
+ * REAL dispatch, as everywhere else in this suite. The one thing replaced is
+ * the registry itself: an https stream wrapper stands in for Packagist so the
+ * test can decide what the network does, instead of asking the internet what
+ * it feels like today.
+ */
+
+require_once __DIR__ . '/../Tina4/DevAdmin.php';
+
+use PHPUnit\Framework\TestCase;
+use Tina4\App;
+use Tina4\DevAdmin;
+use Tina4\ErrorTracker;
+use Tina4\McpServer;
+use Tina4\Middleware;
+use Tina4\Request;
+use Tina4\Response;
+use Tina4\Router;
+
+/** Stands in for repo.packagist.org. A null body means the fetch fails. */
+class FakeRegistryStream
+{
+    public static ?string $body = null;
+    /** @var resource|null */
+    public $context;
+    private int $pos = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        if (self::$body === null) {
+            return false;
+        }
+        $this->pos = 0;
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $out = substr(self::$body ?? '', $this->pos, $count);
+        $this->pos += strlen($out);
+        return $out;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->pos >= strlen(self::$body ?? '');
+    }
+
+    /** @return array<string,int> */
+    public function stream_stat(): array
+    {
+        return [];
+    }
+
+    /** @return array<string,int> */
+    public function url_stat(string $path, int $flags): array
+    {
+        return [];
+    }
+
+    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    {
+        return false;
+    }
+}
+
+class DevAdminVersionCheckTest extends TestCase
+{
+    private string|false $savedDebug = false;
+
+    protected function setUp(): void
+    {
+        $this->savedDebug = getenv('TINA4_DEBUG');
+        putenv('TINA4_DEBUG=true');
+        $_ENV['TINA4_DEBUG'] = 'true';
+        FakeRegistryStream::$body = null;
+        stream_wrapper_unregister('https');
+        stream_wrapper_register('https', FakeRegistryStream::class);
+        DevAdmin::register();
+    }
+
+    protected function tearDown(): void
+    {
+        stream_wrapper_restore('https');
+        Router::clear();
+        // DevAdmin::register() installs error and exception handlers; the rest
+        // of the suite tears them down the same way.
+        Middleware::reset();
+        McpServer::resetDefaultServer();
+        ErrorTracker::reset();
+        FakeRegistryStream::$body = null;
+        unset($_ENV['TINA4_DEBUG']);
+        $this->savedDebug === false ? putenv('TINA4_DEBUG') : putenv("TINA4_DEBUG={$this->savedDebug}");
+    }
+
+    /** @return array<string,mixed> */
+    private function check(): array
+    {
+        $request = Request::create(method: 'GET', path: '/__dev/api/version-check', remoteIp: '127.0.0.1');
+        $response = Router::dispatch($request, new Response(true));
+        return json_decode($response->getBody(), true);
+    }
+
+    /** A Packagist body carrying the given version strings. */
+    private static function registryBody(array $versions): string
+    {
+        return json_encode([
+            'packages' => [
+                'tina4stack/tina4php' => array_map(fn($v) => ['version' => $v], $versions),
+            ],
+        ]);
+    }
+
+    public function testAnUnreachableRegistryIsNotReportedAsUpToDate(): void
+    {
+        FakeRegistryStream::$body = null; // the fetch fails outright
+
+        $payload = $this->check();
+
+        $this->assertNull($payload['latest'], 'a check that did not happen must not answer with a version');
+        $this->assertNotSame($payload['current'], $payload['latest'], 'the toolbar reads latest == current as "you are up to date"');
+        $this->assertNotEmpty($payload['error'] ?? '', 'the reason has to reach the client');
+        $this->assertSame(App::$VERSION, $payload['current']);
+    }
+
+    public function testAnAnswerWithNoStableVersionIsNotReportedAsUpToDate(): void
+    {
+        // Reaching Packagist is not the same as learning the version.
+        FakeRegistryStream::$body = self::registryBody(['dev-main', '3.13.131-rc1']);
+
+        $payload = $this->check();
+
+        $this->assertNull($payload['latest']);
+        $this->assertNotEmpty($payload['error'] ?? '');
+    }
+
+    public function testAReachableRegistryReportsTheHighestStableVersion(): void
+    {
+        FakeRegistryStream::$body = self::registryBody(['3.13.125', 'dev-main', '3.13.131', '3.13.9']);
+
+        $payload = $this->check();
+
+        $this->assertSame('3.13.131', $payload['latest']);
+        $this->assertArrayNotHasKey('error', $payload);
+    }
+
+    public function testTheToolbarActsOnAMissingLatestBeforeComparingVersions(): void
+    {
+        $request = Request::create(method: 'GET', path: '/__dev/toolbar.js', remoteIp: '127.0.0.1');
+        $js = Router::dispatch($request, new Response(true))->getBody();
+
+        $this->assertStringContainsString('couldNotCheck', $js, 'no branch for a check that did not happen');
+        $this->assertStringContainsString('if (!latest) { couldNotCheck', $js);
+        $this->assertLessThan(
+            strpos($js, 'if (latest === current)'),
+            strpos($js, 'if (!latest)'),
+            'the up-to-date branch must not run first — a null would fall into it'
+        );
+    }
+}


### PR DESCRIPTION
## The problem

The dev-admin version check answers `200 OK` with `latest == current` when it never reached the
package registry at all. The toolbar reads that as a match and renders a green
**"Latest: vX — You are up to date!"**.

So a developer several releases behind, on a machine with no route out, is told the opposite of
the truth. The handler initialises `latest = current`, wraps the registry call in a catch-all,
and returns the placeholder on any failure — offline, DNS failure, timeout, a non-2xx, or an
answer it could not read a version out of.

The client is already correct and unreachable: the toolbar's `.catch` writes
`Could not check for updates (offline?)`, and it can never fire, because the server turned the
failure into a success.

## The fix

`latest` is `null` when the check could not be made, and an `error` string says why. The toolbar
branches on the null **before** comparing versions, so a failed check reads as a failed check.

Reaching the registry and failing to read a version out of the answer takes the same path — it
is the same claim by another route.

## Reproducing it

Pin the framework behind the latest release, then ask `/__dev/api/version-check` twice — once
with the network up, once with it unreachable. The two answers should differ.

Before:

```
online:  {"current":"3.13.125","latest":"3.13.134"}
offline: {"current":"3.13.125","latest":"3.13.125"}   <- green "You are up to date!"
```

After:

```
online:  {"current":"3.13.134","latest":"3.13.134"}
offline: {"current":"3.13.134","latest":null,"error":"..."}
```

## Tests

Four new tests in `tests/DevAdminVersionCheckTest.php`. They drive the real front controller
through `Router::dispatch()` and register a stream wrapper over `https` to stand in for
Packagist, so the route is exercised the way a browser hits it.

Full suite on this branch: 5699 tests against the base's 5695, with the same 13 failures and 1
error the untouched base has. Each piece of the fix was reverted on its own to confirm it turns
a test red by itself.
